### PR TITLE
[core] add partial circle poly evaluation skeletons

### DIFF
--- a/packages/core/src/poly/circle/evaluation.ts
+++ b/packages/core/src/poly/circle/evaluation.ts
@@ -1,138 +1,89 @@
-/*
-This is below is the evaluation.rs file that needs to be ported to this TypeScript evaluation.ts file.
-```rs
-use std::marker::PhantomData;
-use std::ops::{Deref, Index};
+// TODO: import { CircleDomain } from "./domain";
+// TODO: import { CirclePoly } from "./poly";
+// TODO: import type { PolyOps } from "./ops";
+// TODO: import type { ColumnOps } from "../../backend"; // placeholder path
+// TODO: import type { SimdBackend, CpuBackend } from "../../backend";
+// TODO: import { TwiddleTree } from "../twiddles";
+// TODO: import type { ExtensionOf } from "../../fields";
 
-use educe::Educe;
+/**
+ * Below is the evaluation.rs file that needs to be ported. The TypeScript version
+ * defines generic circle evaluation logic operating over a backend `B` and field `F`.
+ */
 
-use super::{CircleDomain, CirclePoly, PolyOps};
-use crate::core::backend::simd::SimdBackend;
-use crate::core::backend::{Col, Column, ColumnOps, CpuBackend};
-use crate::core::fields::m31::BaseField;
-use crate::core::fields::ExtensionOf;
-use crate::core::poly::twiddles::TwiddleTree;
-use crate::core::poly::{BitReversedOrder, NaturalOrder};
+export class NaturalOrder {}
+export class BitReversedOrder {}
 
-/// An evaluation defined on a [CircleDomain].
-/// The values are ordered according to the [CircleDomain] ordering.
-#[derive(Educe)]
-#[educe(Clone, Debug)]
-pub struct CircleEvaluation<B: ColumnOps<F>, F: ExtensionOf<BaseField>, EvalOrder = NaturalOrder> {
-    pub domain: CircleDomain,
-    pub values: Col<B, F>,
-    _eval_order: PhantomData<EvalOrder>,
+export interface ColumnOps<F> {
+  bitReverseColumn(col: F[]): void;
+  // Backend specific conversion utilities may be defined elsewhere
 }
 
-impl<B: ColumnOps<F>, F: ExtensionOf<BaseField>, EvalOrder> CircleEvaluation<B, F, EvalOrder> {
-    pub fn new(domain: CircleDomain, values: Col<B, F>) -> Self {
-        assert_eq!(domain.size(), values.len());
-        Self {
-            domain,
-            values,
-            _eval_order: PhantomData,
-        }
+export class CircleEvaluation<B extends ColumnOps<F>, F, EvalOrder = NaturalOrder> {
+  domain: any; // TODO: replace with CircleDomain
+  values: F[];
+
+  private _evalOrder!: EvalOrder;
+
+  constructor(domain: any, values: F[]) {
+    if ((domain as any).size() !== values.length) {
+      throw new Error("CircleEvaluation: domain/values size mismatch");
     }
+    this.domain = domain;
+    this.values = values;
+  }
+
+  static new<B extends ColumnOps<F>, F, E = NaturalOrder>(
+    domain: any,
+    values: F[],
+  ): CircleEvaluation<B, F, E> {
+    return new CircleEvaluation<B, F, E>(domain, values);
+  }
+
+  bitReverse(this: CircleEvaluation<B, F, NaturalOrder>): CircleEvaluation<B, F, BitReversedOrder> {
+    (this.constructor as unknown as { bitReverseColumn(col: F[]): void }).bitReverseColumn(this.values);
+    return CircleEvaluation.new<B, F, BitReversedOrder>(this.domain, this.values);
+  }
+
+  bitReverseBack(this: CircleEvaluation<B, F, BitReversedOrder>): CircleEvaluation<B, F, NaturalOrder> {
+    (this.constructor as unknown as { bitReverseColumn(col: F[]): void }).bitReverseColumn(this.values);
+    return CircleEvaluation.new<B, F, NaturalOrder>(this.domain, this.values);
+  }
+
+  interpolate(this: CircleEvaluation<any, any, BitReversedOrder>): any {
+    const BClass: any = this.constructor;
+    const coset = (this.domain as any).halfCoset;
+    return BClass.interpolate(this, BClass.precomputeTwiddles(coset));
+  }
+
+  interpolateWithTwiddles(this: CircleEvaluation<any, any, BitReversedOrder>, twiddles: any): any {
+    const BClass: any = this.constructor;
+    return BClass.interpolate(this, twiddles);
+  }
+
+  toCpu(this: CircleEvaluation<any, F, EvalOrder>): CircleEvaluation<any, F, EvalOrder> {
+    const BClass: any = this.constructor;
+    return CircleEvaluation.new(BClass.to_cpu(this.values), this.domain);
+  }
+
+  deref(): F[] {
+    return this.values;
+  }
 }
 
-// Note: The concrete implementation of the poly operations is in the specific backend used.
-// For example, the CPU backend implementation is in `src/core/backend/cpu/poly.rs`.
-// TODO(first) Remove NaturalOrder.
-impl<F: ExtensionOf<BaseField>, B: ColumnOps<F>> CircleEvaluation<B, F, NaturalOrder> {
-    pub fn bit_reverse(mut self) -> CircleEvaluation<B, F, BitReversedOrder> {
-        B::bit_reverse_column(&mut self.values);
-        CircleEvaluation::new(self.domain, self.values)
-    }
+/**
+ * A sub-evaluation referencing a subset of the values.
+ */
+export class CosetSubEvaluation<F> {
+  constructor(private evaluation: F[], private offset: number, private step: number) {}
+
+  at(index: number): F {
+    const idx = (this.offset + index * this.step) & (this.evaluation.length - 1);
+    return this.evaluation[idx];
+  }
+
+  // Array indexer helpers
+  get(index: number): F {
+    return this.at(index);
+  }
 }
-
-impl<B: PolyOps> CircleEvaluation<B, BaseField, BitReversedOrder> {
-    /// Computes a minimal [CirclePoly] that evaluates to the same values as this evaluation.
-    pub fn interpolate(self) -> CirclePoly<B> {
-        let coset = self.domain.half_coset;
-        B::interpolate(self, &B::precompute_twiddles(coset))
-    }
-
-    /// Computes a minimal [CirclePoly] that evaluates to the same values as this evaluation, using
-    /// precomputed twiddles.
-    pub fn interpolate_with_twiddles(self, twiddles: &TwiddleTree<B>) -> CirclePoly<B> {
-        B::interpolate(self, twiddles)
-    }
-}
-
-impl<B: ColumnOps<F>, F: ExtensionOf<BaseField>> CircleEvaluation<B, F, BitReversedOrder> {
-    pub fn bit_reverse(mut self) -> CircleEvaluation<B, F, NaturalOrder> {
-        B::bit_reverse_column(&mut self.values);
-        CircleEvaluation::new(self.domain, self.values)
-    }
-}
-
-impl<F: ExtensionOf<BaseField>, EvalOrder> CircleEvaluation<SimdBackend, F, EvalOrder>
-where
-    SimdBackend: ColumnOps<F>,
-{
-    pub fn to_cpu(&self) -> CircleEvaluation<CpuBackend, F, EvalOrder> {
-        CircleEvaluation::new(self.domain, self.values.to_cpu())
-    }
-}
-
-impl<B: ColumnOps<F>, F: ExtensionOf<BaseField>, EvalOrder> Deref
-    for CircleEvaluation<B, F, EvalOrder>
-{
-    type Target = Col<B, F>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.values
-    }
-}
-
-/// A part of a [CircleEvaluation], for a specific coset that is a subset of the circle domain.
-pub struct CosetSubEvaluation<'a, F: ExtensionOf<BaseField>> {
-    evaluation: &'a [F],
-    offset: usize,
-    step: isize,
-}
-
-impl<F: ExtensionOf<BaseField>> Index<isize> for CosetSubEvaluation<'_, F> {
-    type Output = F;
-
-    fn index(&self, index: isize) -> &Self::Output {
-        let index =
-            ((self.offset as isize) + index * self.step) & ((self.evaluation.len() - 1) as isize);
-        &self.evaluation[index as usize]
-    }
-}
-
-impl<F: ExtensionOf<BaseField>> Index<usize> for CosetSubEvaluation<'_, F> {
-    type Output = F;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        &self[index as isize]
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::core::backend::cpu::CpuCircleEvaluation;
-    use crate::core::fields::m31::BaseField;
-    use crate::core::poly::circle::CanonicCoset;
-    use crate::core::poly::NaturalOrder;
-    use crate::m31;
-
-    #[test]
-    fn test_interpolate_non_canonic() {
-        let domain = CanonicCoset::new(3).circle_domain();
-        assert_eq!(domain.log_size(), 3);
-        let evaluation = CpuCircleEvaluation::<_, NaturalOrder>::new(
-            domain,
-            (0..8).map(BaseField::from_u32_unchecked).collect(),
-        )
-        .bit_reverse();
-        let poly = evaluation.interpolate();
-        for (i, point) in domain.iter().enumerate() {
-            assert_eq!(poly.eval_at_point(point.into_ef()), m31!(i as u32).into());
-        }
-    }
-}
-```
-*/
-

--- a/packages/core/src/poly/circle/poly.ts
+++ b/packages/core/src/poly/circle/poly.ts
@@ -1,123 +1,49 @@
-/*
-This is below is the poly.rs file that needs to be ported to this TypeScript poly.ts file.
-```rs
-use super::{CircleDomain, CircleEvaluation, PolyOps};
-use crate::core::backend::{Col, Column, ColumnOps};
-use crate::core::circle::CirclePoint;
-use crate::core::fields::m31::BaseField;
-use crate::core::fields::qm31::SecureField;
-use crate::core::poly::twiddles::TwiddleTree;
-use crate::core::poly::BitReversedOrder;
+// TODO: import { CircleDomain } from "./domain";
+// TODO: import { CircleEvaluation } from "./evaluation";
+// TODO: import type { PolyOps } from "./ops";
+// TODO: import { TwiddleTree } from "../twiddles";
+// TODO: import type { ColumnOps } from "../../backend";
+// TODO: import type { M31 as BaseField } from "../../fields/m31";
 
-/// A polynomial defined on a [CircleDomain].
-#[derive(Clone, Debug)]
-pub struct CirclePoly<B: ColumnOps<BaseField>> {
-    /// Coefficients of the polynomial in the FFT basis.
-    /// Note: These are not the coefficients of the polynomial in the standard
-    /// monomial basis. The FFT basis is a tensor product of the twiddles:
-    /// y, x, pi(x), pi^2(x), ..., pi^{log_size-2}(x).
-    /// pi(x) := 2x^2 - 1.
-    pub coeffs: Col<B, BaseField>,
-    /// The number of coefficients stored as `log2(len(coeffs))`.
-    log_size: u32,
+/** A polynomial defined on a CircleDomain. */
+export class CirclePoly<B extends ColumnOps<any>> {
+  coeffs: any[]; // TODO: use proper Col<B, BaseField>
+  private logSizeValue: number;
+
+  constructor(coeffs: any[]) {
+    if (coeffs.length === 0 || (coeffs.length & (coeffs.length - 1)) !== 0) {
+      throw new Error("coeffs length must be a power of two");
+    }
+    this.coeffs = coeffs;
+    this.logSizeValue = Math.log2(coeffs.length);
+  }
+
+  static new<B extends ColumnOps<any>>(coeffs: any[]): CirclePoly<B> {
+    return new CirclePoly<B>(coeffs);
+  }
+
+  logSize(): number {
+    return this.logSizeValue;
+  }
+
+  evalAtPoint(point: any): any {
+    const BClass: any = (this.constructor as any);
+    return BClass.eval_at_point(this, point);
+  }
+
+  extend(logSize: number): CirclePoly<B> {
+    const BClass: any = (this.constructor as any);
+    return BClass.extend(this, logSize);
+  }
+
+  evaluate(domain: any): any {
+    const BClass: any = (this.constructor as any);
+    const tw = BClass.precomputeTwiddles(domain.halfCoset);
+    return BClass.evaluate(this, domain, tw);
+  }
+
+  evaluateWithTwiddles(domain: any, twiddles: TwiddleTree<B, any>): any {
+    const BClass: any = (this.constructor as any);
+    return BClass.evaluate(this, domain, twiddles);
+  }
 }
-
-impl<B: PolyOps> CirclePoly<B> {
-    /// Creates a new circle polynomial.
-    ///
-    /// Coefficients must be in the circle IFFT algorithm's basis stored in bit-reversed order.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the number of coefficients isn't a power of two.
-    pub fn new(coeffs: Col<B, BaseField>) -> Self {
-        assert!(coeffs.len().is_power_of_two());
-        let log_size = coeffs.len().ilog2();
-        Self { log_size, coeffs }
-    }
-
-    pub const fn log_size(&self) -> u32 {
-        self.log_size
-    }
-
-    /// Evaluates the polynomial at a single point.
-    pub fn eval_at_point(&self, point: CirclePoint<SecureField>) -> SecureField {
-        B::eval_at_point(self, point)
-    }
-
-    /// Extends the polynomial to a larger degree bound.
-    pub fn extend(&self, log_size: u32) -> Self {
-        B::extend(self, log_size)
-    }
-
-    /// Evaluates the polynomial at all points in the domain.
-    pub fn evaluate(
-        &self,
-        domain: CircleDomain,
-    ) -> CircleEvaluation<B, BaseField, BitReversedOrder> {
-        B::evaluate(self, domain, &B::precompute_twiddles(domain.half_coset))
-    }
-
-    /// Evaluates the polynomial at all points in the domain, using precomputed twiddles.
-    pub fn evaluate_with_twiddles(
-        &self,
-        domain: CircleDomain,
-        twiddles: &TwiddleTree<B>,
-    ) -> CircleEvaluation<B, BaseField, BitReversedOrder> {
-        B::evaluate(self, domain, twiddles)
-    }
-}
-
-#[cfg(test)]
-impl crate::core::backend::cpu::CpuCirclePoly {
-    pub fn is_in_fft_space(&self, log_fft_size: u32) -> bool {
-        use num_traits::Zero;
-
-        let mut coeffs = self.coeffs.clone();
-        while coeffs.last() == Some(&BaseField::zero()) {
-            coeffs.pop();
-        }
-
-        // The highest degree monomial in a fft-space polynomial is x^{(n/2) - 1}y.
-        // And it is at offset (n-1). x^{(n/2)} is at offset `n`, and is not allowed.
-        let highest_degree_allowed_monomial_offset = 1 << log_fft_size;
-        coeffs.len() <= highest_degree_allowed_monomial_offset
-    }
-
-    /// Fri space is the space of polynomials of total degree n/2.
-    /// Highest degree monomials are x^{n/2} and x^{(n/2)-1}y.
-    pub fn is_in_fri_space(&self, log_fft_size: u32) -> bool {
-        use num_traits::Zero;
-
-        let mut coeffs = self.coeffs.clone();
-        while coeffs.last() == Some(&BaseField::zero()) {
-            coeffs.pop();
-        }
-
-        // x^{n/2} is at offset `n`, and is the last offset allowed to be non-zero.
-        let highest_degree_monomial_offset = (1 << log_fft_size) + 1;
-        coeffs.len() <= highest_degree_monomial_offset
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::core::backend::cpu::CpuCirclePoly;
-    use crate::core::circle::CirclePoint;
-    use crate::core::fields::m31::BaseField;
-
-    #[test]
-    fn test_circle_poly_extend() {
-        let poly = CpuCirclePoly::new((0..16).map(BaseField::from_u32_unchecked).collect());
-        let extended = poly.clone().extend(8);
-        let random_point = CirclePoint::get_point(21903);
-
-        assert_eq!(
-            poly.eval_at_point(random_point),
-            extended.eval_at_point(random_point)
-        );
-    }
-}
-```
-*/
-

--- a/packages/core/src/poly/circle/secure_poly.ts
+++ b/packages/core/src/poly/circle/secure_poly.ts
@@ -1,135 +1,63 @@
-/*
-This is below is the secure_poly.rs file that needs to be ported to this TypeScript secure_poly.ts file.
-```rs
-use std::marker::PhantomData;
-use std::ops::{Deref, DerefMut};
+// TODO: import { CircleDomain } from "./domain";
+// TODO: import { CircleEvaluation } from "./evaluation";
+// TODO: import { CirclePoly } from "./poly";
+// TODO: import type { PolyOps } from "./ops";
+// TODO: import type { ColumnOps } from "../../backend";
+// TODO: import { TwiddleTree } from "../twiddles";
+// TODO: import type { SecureField } from "../../fields/qm31";
 
-use super::{CircleDomain, CircleEvaluation, CirclePoly, PolyOps};
-use crate::core::backend::{ColumnOps, CpuBackend};
-use crate::core::circle::CirclePoint;
-use crate::core::fields::m31::BaseField;
-use crate::core::fields::qm31::SecureField;
-use crate::core::fields::secure_column::{SecureColumnByCoords, SECURE_EXTENSION_DEGREE};
-use crate::core::poly::twiddles::TwiddleTree;
-use crate::core::poly::BitReversedOrder;
+export const SECURE_EXTENSION_DEGREE = 4; // placeholder constant
 
-pub struct SecureCirclePoly<B: ColumnOps<BaseField>>(pub [CirclePoly<B>; SECURE_EXTENSION_DEGREE]);
+export class SecureCirclePoly<B extends ColumnOps<any>> {
+  constructor(public polys: [CirclePoly<B>, CirclePoly<B>, CirclePoly<B>, CirclePoly<B>]) {}
 
-impl<B: PolyOps> SecureCirclePoly<B> {
-    pub fn eval_at_point(&self, point: CirclePoint<SecureField>) -> SecureField {
-        SecureField::from_partial_evals(self.eval_columns_at_point(point))
-    }
+  evalAtPoint(point: any): any {
+    // TODO: combine coordinate evaluations as SecureField when implemented
+    return this.polys[0].evalAtPoint(point);
+  }
 
-    pub fn eval_columns_at_point(
-        &self,
-        point: CirclePoint<SecureField>,
-    ) -> [SecureField; SECURE_EXTENSION_DEGREE] {
-        [
-            self[0].eval_at_point(point),
-            self[1].eval_at_point(point),
-            self[2].eval_at_point(point),
-            self[3].eval_at_point(point),
-        ]
-    }
+  evalColumnsAtPoint(point: any): any[] {
+    return this.polys.map((p) => p.evalAtPoint(point));
+  }
 
-    pub fn log_size(&self) -> u32 {
-        self[0].log_size()
-    }
+  logSize(): number {
+    return this.polys[0].logSize();
+  }
 
-    pub fn evaluate_with_twiddles(
-        &self,
-        domain: CircleDomain,
-        twiddles: &TwiddleTree<B>,
-    ) -> SecureEvaluation<B, BitReversedOrder> {
-        let polys = self.0.each_ref();
-        let columns = polys.map(|poly| poly.evaluate_with_twiddles(domain, twiddles).values);
-        SecureEvaluation::new(domain, SecureColumnByCoords { columns })
-    }
+  evaluateWithTwiddles(domain: any, twiddles: TwiddleTree<B, any>): SecureEvaluation<B, BitReversedOrder> {
+    const columns = this.polys.map((p) => p.evaluateWithTwiddles(domain, twiddles).values);
+    return new SecureEvaluation(domain, { columns } as any);
+  }
 
-    pub fn into_coordinate_polys(self) -> [CirclePoly<B>; SECURE_EXTENSION_DEGREE] {
-        self.0
-    }
+  intoCoordinatePolys(): [CirclePoly<B>, CirclePoly<B>, CirclePoly<B>, CirclePoly<B>] {
+    return this.polys;
+  }
 }
 
-impl<B: ColumnOps<BaseField>> Deref for SecureCirclePoly<B> {
-    type Target = [CirclePoly<B>; SECURE_EXTENSION_DEGREE];
-
-    fn deref(&self) -> &Self::Target {
-        &self.0
+export class SecureEvaluation<B extends ColumnOps<any>, EvalOrder> {
+  constructor(public domain: any, public values: any, private _evalOrder?: EvalOrder) {
+    if ((domain as any).size() !== values.len) {
+      throw new Error("SecureEvaluation: size mismatch");
     }
+  }
+
+  intoCoordinateEvals(): any[] {
+    const { domain, values } = this;
+    return values.columns.map((c: any) => new CircleEvaluation<B, any, EvalOrder>(domain, c));
+  }
+
+  toCpu(): SecureEvaluation<any, EvalOrder> {
+    return new SecureEvaluation(this.domain, this.values.to_cpu(), this._evalOrder);
+  }
+
+  interpolateWithTwiddles(twiddles: TwiddleTree<B, any>): SecureCirclePoly<B> {
+    const domain = this.domain;
+    const cols = this.values.columns;
+    const polys = cols.map((c: any) =>
+      new CircleEvaluation<B, any, BitReversedOrder>(domain, c).interpolateWithTwiddles(twiddles),
+    );
+    return new SecureCirclePoly(polys as any);
+  }
 }
 
-/// A [`SecureField`] evaluation defined on a [CircleDomain].
-///
-/// The evaluation is stored as a column major array of [`SECURE_EXTENSION_DEGREE`] many base field
-/// evaluations. The evaluations are ordered according to the [CircleDomain] ordering.
-#[derive(Clone)]
-pub struct SecureEvaluation<B: ColumnOps<BaseField>, EvalOrder> {
-    pub domain: CircleDomain,
-    pub values: SecureColumnByCoords<B>,
-    _eval_order: PhantomData<EvalOrder>,
-}
-
-impl<B: ColumnOps<BaseField>, EvalOrder> SecureEvaluation<B, EvalOrder> {
-    pub fn new(domain: CircleDomain, values: SecureColumnByCoords<B>) -> Self {
-        assert_eq!(domain.size(), values.len());
-        Self {
-            domain,
-            values,
-            _eval_order: PhantomData,
-        }
-    }
-
-    pub fn into_coordinate_evals(
-        self,
-    ) -> [CircleEvaluation<B, BaseField, EvalOrder>; SECURE_EXTENSION_DEGREE] {
-        let Self { domain, values, .. } = self;
-        values.columns.map(|c| CircleEvaluation::new(domain, c))
-    }
-
-    pub fn to_cpu(&self) -> SecureEvaluation<CpuBackend, EvalOrder> {
-        SecureEvaluation {
-            domain: self.domain,
-            values: self.values.to_cpu(),
-            _eval_order: PhantomData,
-        }
-    }
-}
-
-impl<B: ColumnOps<BaseField>, EvalOrder> Deref for SecureEvaluation<B, EvalOrder> {
-    type Target = SecureColumnByCoords<B>;
-
-    fn deref(&self) -> &Self::Target {
-        &self.values
-    }
-}
-
-impl<B: ColumnOps<BaseField>, EvalOrder> DerefMut for SecureEvaluation<B, EvalOrder> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.values
-    }
-}
-
-impl<B: PolyOps> SecureEvaluation<B, BitReversedOrder> {
-    /// Computes a minimal [`SecureCirclePoly`] that evaluates to the same values as this
-    /// evaluation, using precomputed twiddles.
-    pub fn interpolate_with_twiddles(self, twiddles: &TwiddleTree<B>) -> SecureCirclePoly<B> {
-        let domain = self.domain;
-        let cols = self.values.columns;
-        SecureCirclePoly(cols.map(|c| {
-            CircleEvaluation::<B, BaseField, BitReversedOrder>::new(domain, c)
-                .interpolate_with_twiddles(twiddles)
-        }))
-    }
-}
-
-impl<EvalOrder> From<CircleEvaluation<CpuBackend, SecureField, EvalOrder>>
-    for SecureEvaluation<CpuBackend, EvalOrder>
-{
-    fn from(evaluation: CircleEvaluation<CpuBackend, SecureField, EvalOrder>) -> Self {
-        Self::new(evaluation.domain, evaluation.values.into_iter().collect())
-    }
-}
-```
-*/
-
+// TODO: import { BitReversedOrder } from "../index";

--- a/packages/core/src/poly/line.ts
+++ b/packages/core/src/poly/line.ts
@@ -1,6 +1,5 @@
-/*
-This is below is the line.rs file that needs to be ported to this TypeScript line.ts file.
-```rs
+// TODO: implement line domain utilities once the Rust logic is available.
 
-```
-*/
+export class LineDomain {
+  // placeholder for fields and methods
+}


### PR DESCRIPTION
## Summary
- add placeholder implementations for circle polynomial evaluation modules
- provide skeletal CirclePoly, SecureCirclePoly, and evaluation structures
- add TODO imports and placeholders for future translations

## Testing
- `bun run --cwd packages/core test`
