### PR TITLE
[repo] add coverage configuration and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,10 @@ jobs:
       - name: Build
         run: bun run build
       
-      - name: Test
-        run: bun run test 
+      - name: Test with coverage
+        run: bun run test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: ./packages/core/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
   <a href="https://github.com/teddyjfpender/tstwo/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/teddyjfpender/tstwo/ci.yml?branch=main" alt="Build Status"></a>
+  <a href="https://codecov.io/gh/teddyjfpender/tstwo"><img src="https://codecov.io/gh/teddyjfpender/tstwo/branch/main/graph/badge.svg" alt="Coverage status"/></a>
 </p>
 
 [Stwo](https://github.com/starkware-libs/stwo/) re-written in TypeScript, by AI.

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,5 @@
+[test]
+coverage = true
+coverageReporter = ["text", "lcov"]
+coverageDir = "coverage"
+coverageSkipTestFiles = true


### PR DESCRIPTION
## Summary
- enable Bun coverage reporting and lcov export
- publish lcov to Codecov in CI
- show Codecov badge in README

## Testing
- `bun run test` *(fails: E2BIG)*
- `bun run lint` *(fails: E2BIG)*