### PR TITLE
[core] port circle ops trait and exports

### DIFF
--- a/packages/core/src/poly/circle/circle.ts
+++ b/packages/core/src/poly/circle/circle.ts
@@ -60,3 +60,18 @@ mod tests {
 ```
 */
 
+// Re-export the circle polynomial utilities. This mirrors the `mod.rs` module
+// from the Rust implementation, providing a single entry point for all circle
+// related types.
+
+export { CanonicCoset } from "./canonic";
+export {
+  CircleDomain,
+  MAX_CIRCLE_DOMAIN_LOG_SIZE,
+} from "./domain";
+export { CircleEvaluation, CosetSubEvaluation } from "./evaluation";
+export { PolyOps } from "./ops";
+export { CirclePoly } from "./poly";
+export { SecureCirclePoly, SecureEvaluation } from "./secure_poly";
+
+

--- a/packages/core/src/poly/circle/ops.ts
+++ b/packages/core/src/poly/circle/ops.ts
@@ -73,3 +73,109 @@ pub trait PolyOps: ColumnOps<BaseField> + Sized {
 ```
 */
 
+// TODO: import type { CirclePoint, Coset } from "../../circle";
+// Once the circle geometry module is ported, update these imports and ensure the
+// types match the Rust definitions.
+
+// TODO: import type { SecureField } from "../../fields/qm31";
+// Once the secure field implementation is available, replace `unknown` with
+// `SecureField`.
+
+import type { M31 as BaseField } from "../../fields/m31";
+import type { CanonicCoset } from "./canonic";
+import type { CircleDomain } from "./domain";
+import type { CircleEvaluation, BitReversedOrder, ColumnOps } from "./evaluation";
+import type { CirclePoly } from "./poly";
+import type { TwiddleTree } from "../twiddles";
+
+/**
+ * Operations on base field polynomials.
+ *
+ * This interface mirrors the Rust `PolyOps` trait. Implementations should
+ * provide efficient FFT and polynomial arithmetic routines specialized for a
+ * particular backend `B`.
+ */
+export interface PolyOps<B extends ColumnOps<BaseField>, Twiddles = unknown>
+  extends ColumnOps<BaseField> {
+  /** Computes a polynomial that evaluates to the given values. */
+  interpolate(
+    eval_: CircleEvaluation<B, BaseField, BitReversedOrder>,
+    itwiddles: TwiddleTree<B, Twiddles>,
+  ): CirclePoly<B>;
+
+  /**
+   * Computes multiple polynomials by interpolating each evaluation column.
+   *
+   * Implementations may override this for efficiency. The default logic is
+   * provided by {@link interpolateColumnsDefault}.
+   */
+  interpolateColumns?(
+    columns: Iterable<CircleEvaluation<B, BaseField, BitReversedOrder>>,
+    twiddles: TwiddleTree<B, Twiddles>,
+  ): CirclePoly<B>[];
+
+  /** Evaluates the polynomial at a single point. */
+  evalAtPoint(poly: CirclePoly<B>, point: unknown /* CirclePoint<SecureField> */): unknown /* SecureField */;
+
+  /** Extends the polynomial to a larger degree bound. */
+  extend(poly: CirclePoly<B>, logSize: number): CirclePoly<B>;
+
+  /** Evaluates the polynomial over an entire domain. */
+  evaluate(
+    poly: CirclePoly<B>,
+    domain: CircleDomain,
+    twiddles: TwiddleTree<B, Twiddles>,
+  ): CircleEvaluation<B, BaseField, BitReversedOrder>;
+
+  /**
+   * Evaluates multiple polynomials on a larger domain with a blowup factor.
+   *
+   * Implementations may override this for efficiency. The default logic is
+   * provided by {@link evaluatePolynomialsDefault}.
+   */
+  evaluatePolynomials?(
+    polynomials: readonly CirclePoly<B>[],
+    logBlowupFactor: number,
+    twiddles: TwiddleTree<B, Twiddles>,
+  ): CircleEvaluation<B, BaseField, BitReversedOrder>[];
+
+  /** Precomputes twiddles for a given coset. */
+  precomputeTwiddles(coset: unknown /* Coset */): TwiddleTree<B, Twiddles>;
+}
+
+/**
+ * Default implementation of `interpolateColumns` following the behavior of the
+ * Rust trait. It iterates over the provided evaluations and interpolates each
+ * one using the given twiddle tree.
+ */
+export function interpolateColumnsDefault<B extends ColumnOps<BaseField>, T>(
+  columns: Iterable<CircleEvaluation<B, BaseField, BitReversedOrder>>,
+  twiddles: TwiddleTree<B, T>,
+): CirclePoly<B>[] {
+  const result: CirclePoly<B>[] = [];
+  for (const evaluation of columns) {
+    result.push(evaluation.interpolateWithTwiddles(twiddles));
+  }
+  return result;
+}
+
+/**
+ * Default implementation of `evaluatePolynomials` following the Rust trait. It
+ * evaluates each polynomial on a blown-up canonic domain using the supplied
+ * twiddle tree.
+ */
+export function evaluatePolynomialsDefault<B extends ColumnOps<BaseField>, T>(
+  polynomials: readonly CirclePoly<B>[],
+  logBlowupFactor: number,
+  twiddles: TwiddleTree<B, T>,
+  CanonicCosetCtor: { new (logSize: number): CanonicCoset },
+): CircleEvaluation<B, BaseField, BitReversedOrder>[] {
+  return polynomials.map((poly) =>
+    poly.evaluateWithTwiddles(
+      new CanonicCosetCtor(poly.logSize() + logBlowupFactor).circleDomain(),
+      twiddles,
+    ),
+  );
+}
+
+

--- a/packages/core/test/poly/ops.test.ts
+++ b/packages/core/test/poly/ops.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test";
+import { interpolateColumnsDefault, evaluatePolynomialsDefault } from "../../src/poly/circle/ops";
+import { TwiddleTree } from "../../src/poly/twiddles";
+
+class DummyEval {
+  constructor(public vals: number[]) {}
+  interpolateWithTwiddles(_: TwiddleTree<any, any>) {
+    return new DummyPoly(this.vals);
+  }
+}
+
+class DummyPoly {
+  constructor(public coeffs: number[]) {}
+  logSize() { return Math.log2(this.coeffs.length); }
+  evaluateWithTwiddles(_: any, __: TwiddleTree<any, any>) {
+    return new DummyEval(this.coeffs);
+  }
+}
+
+class DummyCoset { constructor(public logSizeVal: number) {} circleDomain() { return {}; } }
+
+describe("PolyOps defaults", () => {
+  it("interpolateColumnsDefault maps evaluations", () => {
+    const evals = [new DummyEval([1]), new DummyEval([2,3])];
+    const res = interpolateColumnsDefault(evals, new TwiddleTree(null, null, null));
+    expect(res.length).toBe(2);
+    expect(res[0] instanceof DummyPoly).toBe(true);
+  });
+
+  it("evaluatePolynomialsDefault maps polynomials", () => {
+    const polys = [new DummyPoly([1,2]), new DummyPoly([3,4])];
+    const res = evaluatePolynomialsDefault(polys, 1, new TwiddleTree(null, null, null), DummyCoset);
+    expect(res.length).toBe(2);
+    expect(res[0] instanceof DummyEval).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- port `ops.rs` trait as TypeScript `PolyOps` interface with helpers
- expose circle module exports via `circle.ts`
- add tests for the default `PolyOps` helper functions

## Testing
- `bun test`