### PR TITLE
[core] increase test coverage for circle domain and utils

### DIFF
--- a/packages/core/test/poly/domain.test.ts
+++ b/packages/core/test/poly/domain.test.ts
@@ -10,6 +10,9 @@ class FakeIndex {
   conjugate(): number {
     return -this.value;
   }
+  valueOf(): number {
+    return this.value;
+  }
 }
 
 class FakeCoset {
@@ -85,6 +88,16 @@ describe("CircleDomain", () => {
     const shifted = domain.shift(3);
     expect(shifted.halfCoset.initial_index).toBe(coset.initial_index + 3);
     expect(shifted.halfCoset.log_size).toBe(coset.log_size);
+  });
+
+  it("iterIndices yields indices then their conjugates", () => {
+    const coset = FakeCoset.new(0, 2);
+    const domain = CircleDomain.new(coset);
+    const expected = [
+      ...coset.iter_indices(),
+      ...coset.conjugate().iter_indices(),
+    ];
+    expect(Array.from(domain.iterIndices())).toEqual(expected);
   });
 
 });

--- a/packages/core/test/poly/utils.test.ts
+++ b/packages/core/test/poly/utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { repeatValue } from "../../src/poly/utils";
+import { repeatValue, fold } from "../../src/poly/utils";
+import { M31 } from "../../src/fields/m31";
+import { CM31 } from "../../src/fields/cm31";
 
 describe("repeatValue", () => {
   it("repeat 0 times works", () => {
@@ -12,5 +14,25 @@ describe("repeatValue", () => {
 
   it("repeat 3 times works", () => {
     expect(repeatValue([1, 2], 3)).toEqual([1, 1, 1, 2, 2, 2]);
+  });
+});
+
+describe("fold", () => {
+  it("folds values recursively", () => {
+    const vals = [
+      CM31.fromM31(M31.from(1), M31.zero()),
+      CM31.fromM31(M31.from(2), M31.zero()),
+      CM31.fromM31(M31.from(3), M31.zero()),
+      CM31.fromM31(M31.from(4), M31.zero()),
+    ];
+    const z = CM31.fromM31(M31.from(5), M31.zero());
+    const y = CM31.fromM31(M31.from(6), M31.zero());
+    const res = fold(vals, [y, z]);
+    const expected =
+      vals[0]
+        .add(vals[1].mul(z))
+        .add(vals[2].add(vals[3].mul(z)).mul(y));
+    expect(res.real.value).toBe(expected.real.value);
+    expect(res.imag.value).toBe(expected.imag.value);
   });
 });


### PR DESCRIPTION
## Summary
- add valueOf to FakeIndex helper to allow negation
- test iterIndices on CircleDomain
- test fold recursion on complex field values

## Testing
- `bun test`