### PR TITLE
[core] link circle modules and add basic evaluation test

### DIFF
--- a/packages/core/src/poly/circle/canonic.ts
+++ b/packages/core/src/poly/circle/canonic.ts
@@ -83,8 +83,10 @@ impl CanonicCoset {
 ```
 */
 
-// TODO: import { CircleDomain } from "./domain";
-// Once `domain.ts` is ported, update this import and ensure the API matches the Rust version.
+// Import the circle domain once implemented. This mirrors the Rust `mod.rs` re-export
+// structure where `CanonicCoset` provides convenience constructors for a
+// corresponding `CircleDomain`.
+import { CircleDomain } from "./domain";
 
 // TODO: import { Coset, CirclePoint, CirclePointIndex } from "../../circle";
 // These come from the yet-to-be-translated circle geometry module.

--- a/packages/core/src/poly/circle/evaluation.ts
+++ b/packages/core/src/poly/circle/evaluation.ts
@@ -1,9 +1,10 @@
-// TODO: import { CircleDomain } from "./domain";
-// TODO: import { CirclePoly } from "./poly";
-// TODO: import type { PolyOps } from "./ops";
+// Core circle polynomial structures.
+import type { CircleDomain } from "./domain";
+import type { CirclePoly } from "./poly";
+import type { PolyOps } from "./ops";
 // TODO: import type { ColumnOps } from "../../backend"; // placeholder path
 // TODO: import type { SimdBackend, CpuBackend } from "../../backend";
-// TODO: import { TwiddleTree } from "../twiddles";
+import { TwiddleTree } from "../twiddles";
 // TODO: import type { ExtensionOf } from "../../fields";
 
 /**

--- a/packages/core/src/poly/circle/poly.ts
+++ b/packages/core/src/poly/circle/poly.ts
@@ -1,9 +1,8 @@
-// TODO: import { CircleDomain } from "./domain";
-// TODO: import { CircleEvaluation } from "./evaluation";
-// TODO: import type { PolyOps } from "./ops";
-// TODO: import { TwiddleTree } from "../twiddles";
-// TODO: import type { ColumnOps } from "../../backend";
-// TODO: import type { M31 as BaseField } from "../../fields/m31";
+import type { CircleDomain } from "./domain";
+import { CircleEvaluation, ColumnOps } from "./evaluation";
+import type { PolyOps } from "./ops";
+import { TwiddleTree } from "../twiddles";
+import type { M31 as BaseField } from "../../fields/m31";
 
 /** A polynomial defined on a CircleDomain. */
 export class CirclePoly<B extends ColumnOps<any>> {

--- a/packages/core/src/poly/circle/secure_poly.ts
+++ b/packages/core/src/poly/circle/secure_poly.ts
@@ -1,9 +1,9 @@
-// TODO: import { CircleDomain } from "./domain";
-// TODO: import { CircleEvaluation } from "./evaluation";
-// TODO: import { CirclePoly } from "./poly";
-// TODO: import type { PolyOps } from "./ops";
-// TODO: import type { ColumnOps } from "../../backend";
-// TODO: import { TwiddleTree } from "../twiddles";
+import type { CircleDomain } from "./domain";
+import { CircleEvaluation } from "./evaluation";
+import { CirclePoly } from "./poly";
+import type { PolyOps } from "./ops";
+import type { ColumnOps } from "./evaluation";
+import { TwiddleTree } from "../twiddles";
 // TODO: import type { SecureField } from "../../fields/qm31";
 
 export const SECURE_EXTENSION_DEGREE = 4; // placeholder constant
@@ -60,7 +60,7 @@ export class SecureEvaluation<B extends ColumnOps<any>, EvalOrder> {
   }
 }
 
-// TODO: import { BitReversedOrder } from "../index";
+import { BitReversedOrder } from "../index";
 
 /*
 This is the Rust code from secure_poly.rs that needs to be ported to Typescript in this secure_poly.ts file:

--- a/packages/core/test/poly/cosetSubEvaluation.test.ts
+++ b/packages/core/test/poly/cosetSubEvaluation.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { CosetSubEvaluation } from "../../src/poly/circle/evaluation";
+
+
+describe("CosetSubEvaluation", () => {
+  it("indexes values correctly", () => {
+    const data = [0,1,2,3,4,5,6,7];
+    const sub = new CosetSubEvaluation<number>(data, 1, 2);
+    expect(sub.at(0)).toBe(1);
+    expect(sub.at(1)).toBe(3);
+    expect(sub.get(2)).toBe(5);
+  });
+});
+


### PR DESCRIPTION
## Summary
- hook up imports between circle modules
- use ColumnOps from evaluation in CirclePoly and SecureCirclePoly
- add a simple CosetSubEvaluation test

## Testing
- `bun run test`
- `bun run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*