### PR TITLE
[core] expose circle poly utilities

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,4 +4,7 @@ export const greet = (name: string): string => {
 
 export const sum = (a: number, b: number): number => {
   return a + b;
-}; 
+};
+
+// Expose the polynomial utilities as part of the public API
+export * from "./poly";

--- a/packages/core/src/poly/circle/evaluation.ts
+++ b/packages/core/src/poly/circle/evaluation.ts
@@ -43,12 +43,14 @@ export class CircleEvaluation<B extends ColumnOps<F>, F, EvalOrder = NaturalOrde
 
   bitReverse(this: CircleEvaluation<B, F, NaturalOrder>): CircleEvaluation<B, F, BitReversedOrder> {
     (this.constructor as unknown as { bitReverseColumn(col: F[]): void }).bitReverseColumn(this.values);
-    return CircleEvaluation.new<B, F, BitReversedOrder>(this.domain, this.values);
+    const Ctor = this.constructor as new (d: any, v: F[]) => CircleEvaluation<B, F, BitReversedOrder>;
+    return new Ctor(this.domain, this.values);
   }
 
   bitReverseBack(this: CircleEvaluation<B, F, BitReversedOrder>): CircleEvaluation<B, F, NaturalOrder> {
     (this.constructor as unknown as { bitReverseColumn(col: F[]): void }).bitReverseColumn(this.values);
-    return CircleEvaluation.new<B, F, NaturalOrder>(this.domain, this.values);
+    const Ctor = this.constructor as new (d: any, v: F[]) => CircleEvaluation<B, F, NaturalOrder>;
+    return new Ctor(this.domain, this.values);
   }
 
   interpolate(this: CircleEvaluation<any, any, BitReversedOrder>): any {

--- a/packages/core/src/poly/index.ts
+++ b/packages/core/src/poly/index.ts
@@ -3,9 +3,7 @@ export * from "./line";
 export * from "./twiddles";
 export * from "./utils";
 
-/** Bit-reversed evaluation ordering. */
-export class BitReversedOrder {}
-
-/** Natural evaluation ordering (same order as domain). */
-export class NaturalOrder {}
+// Re-export the evaluation order marker classes from the circle evaluation
+// module so that consumers can import them from `poly` directly.
+export { BitReversedOrder, NaturalOrder } from "./circle/evaluation";
 

--- a/packages/core/test/poly/circleEvaluation.test.ts
+++ b/packages/core/test/poly/circleEvaluation.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { CircleEvaluation } from "../../src/poly/circle/evaluation";
+import { bitReverseIndex } from "../../src/utils";
+
+class DummyEval extends CircleEvaluation<any, number> {
+  static bitReverseColumn(col: number[]): void {
+    const n = col.length;
+    const logSize = Math.log2(n);
+    for (let i = 0; i < n; i++) {
+      const j = bitReverseIndex(i, logSize);
+      if (j > i) {
+        [col[i], col[j]] = [col[j], col[i]];
+      }
+    }
+  }
+}
+
+const dummyDomain = { size: () => 4, halfCoset: null } as any;
+
+describe("CircleEvaluation.bitReverse", () => {
+  it("reverses the evaluation order and back", () => {
+    const evalNat = new DummyEval(dummyDomain, [0, 1, 2, 3]);
+    const evalRev = evalNat.bitReverse();
+    expect(evalRev).toBeInstanceOf(CircleEvaluation);
+    expect(evalRev.values).toEqual([0, 2, 1, 3]);
+    const evalBack = evalRev.bitReverseBack();
+    expect(evalBack.values).toEqual([0, 1, 2, 3]);
+  });
+});
+


### PR DESCRIPTION
## Summary
- re-export core poly modules from the main package
- re-export evaluation order markers from poly
- ensure `CircleEvaluation` preserves subclass when reversing order
- add unit tests for `CircleEvaluation.bitReverse`

## Testing
- `bun run test packages/core`
- `bun run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*