### PR TITLE
[core] expand circle exports

### DIFF
--- a/packages/core/src/poly/circle/circle.ts
+++ b/packages/core/src/poly/circle/circle.ts
@@ -70,7 +70,8 @@ export {
   MAX_CIRCLE_DOMAIN_LOG_SIZE,
 } from "./domain";
 export { CircleEvaluation, CosetSubEvaluation } from "./evaluation";
-export { PolyOps } from "./ops";
+// `PolyOps` is an interface, so re-export it as a type-only export.
+export type { PolyOps } from "./ops";
 export { CirclePoly } from "./poly";
 export { SecureCirclePoly, SecureEvaluation } from "./secure_poly";
 

--- a/packages/core/src/poly/circle/index.ts
+++ b/packages/core/src/poly/circle/index.ts
@@ -4,3 +4,6 @@ export * from "./evaluation";
 export * from "./ops";
 export * from "./poly";
 export * from "./secure_poly";
+// Re-export the module aggregator so consumers can import all circle utilities
+// from `poly/circle` directly, matching the original Rust `mod.rs` structure.
+export * from "./circle";

--- a/packages/core/test/poly/circleMainExports.test.ts
+++ b/packages/core/test/poly/circleMainExports.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import * as circle from "../../src/poly/circle";
+
+describe("circle index exports", () => {
+  it("re-exports circle modules", () => {
+    expect(circle).toHaveProperty("CanonicCoset");
+    expect(circle).toHaveProperty("CircleDomain");
+    expect(circle).toHaveProperty("CircleEvaluation");
+    expect(circle).toHaveProperty("CirclePoly");
+    expect(circle).toHaveProperty("SecureCirclePoly");
+  });
+});


### PR DESCRIPTION
## Summary
- re-export circle module aggregator
- test that poly/circle main entry exposes all submodules

## Testing
- `bun test`
- `bun run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*