### PR TITLE
[core] increase test coverage

### DIFF
--- a/packages/core/test/fields/m31.test.ts
+++ b/packages/core/test/fields/m31.test.ts
@@ -127,4 +127,9 @@ describe("M31", () => {
     expect(M31.zero().isZero()).toBe(true);
     expect(a.isZero()).toBe(false);
   });
+  it("complexConjugate returns self", () => {
+    const v = M31.from(99);
+    expect(v.complexConjugate().value).toBe(99);
+  });
+
 });

--- a/packages/core/test/fields/qm31.test.ts
+++ b/packages/core/test/fields/qm31.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { M31, P } from "../../src/fields/m31";
+import { CM31 } from "../../src/fields/cm31";
 import { QM31 } from "../../src/fields/qm31";
 
 function qm31(m0: number, m1: number, m2: number, m3: number): QM31 {
@@ -88,4 +89,17 @@ describe("QM31", () => {
     const m = QM31.from(m31(5));
     expect(m.tryIntoM31()!.value).toBe(5);
   });
+  it("additional helpers", () => {
+    const arr = [m31(1), m31(2), m31(3), m31(4)];
+    const f1 = QM31.fromM31(arr[0], arr[1], arr[2], arr[3]);
+    const f2 = QM31.fromM31Array(arr);
+    expect(f1.equals(qm31(1,2,3,4))).toBe(true);
+    expect(f2.equals(f1)).toBe(true);
+    expect(f1.toM31Array().map(v => v.value)).toEqual([1,2,3,4]);
+    const cm = CM31.fromUnchecked(5,6);
+    expect(f1.mulCM31(cm).equals(new QM31(f1.c0.mul(cm), f1.c1.mul(cm)))).toBe(true);
+    const conj = f1.complexConjugate();
+    expect(conj.c0.imag.value).toBe(P - 2);
+  });
+
 });

--- a/packages/core/test/poly/canonicCoset.test.ts
+++ b/packages/core/test/poly/canonicCoset.test.ts
@@ -27,6 +27,8 @@ describe("CanonicCoset", () => {
     expect(c.cosetFull().step_size).toBe(2);
     expect((c.halfCoset() as any).log_size).toBe(2);
     expect((c.circleDomain() as any).from.log_size).toBe(2);
+    expect(c.initialIndex()).toBe(1);
+    expect(c.stepSize()).toBe(2);
     expect(c.indexAt(1)).toEqual({ idx: 1, to_point: expect.any(Function) });
     expect(c.at(2)).toBe(2);
   });

--- a/packages/core/test/poly/domain.test.ts
+++ b/packages/core/test/poly/domain.test.ts
@@ -90,6 +90,14 @@ describe("CircleDomain", () => {
     expect(shifted.halfCoset.log_size).toBe(coset.log_size);
   });
 
+  it("size and iterator work", () => {
+    const coset = FakeCoset.new(1,2);
+    const domain = CircleDomain.new(coset);
+    expect(domain.size()).toBe(1 << domain.logSize());
+    const points: number[] = [];
+    for(const p of domain){ points.push(p); }
+    expect(points.length).toBe(domain.size());
+  });
   it("iterIndices yields indices then their conjugates", () => {
     const coset = FakeCoset.new(0, 2);
     const domain = CircleDomain.new(coset);

--- a/packages/core/test/poly/lineDomain.test.ts
+++ b/packages/core/test/poly/lineDomain.test.ts
@@ -25,6 +25,12 @@ describe("LineDomain", () => {
     expect(Array.from(domain.iter())).toEqual([0,1,2,3]);
   });
 
+  it("at returns x and cosetValue exposes coset", () => {
+    const coset = new FakeCoset(2);
+    const domain = LineDomain.new(coset);
+    expect(domain.at(1)).toBe(1);
+    expect(domain.cosetValue()).toBe(coset);
+  });
   it("double halves the domain size", () => {
     const coset = new FakeCoset(4);
     const domain = LineDomain.new(coset);

--- a/packages/core/test/poly/securePoly.test.ts
+++ b/packages/core/test/poly/securePoly.test.ts
@@ -42,4 +42,16 @@ describe("SecureCirclePoly and Evaluation", () => {
     expect(res.intoCoordinatePolys()).toEqual([5,6,7,8]);
     CircleEvaluation.prototype.interpolateWithTwiddles = orig;
   });
+  it("evaluateWithTwiddles delegates to polys", () => {
+    const domain = { size: () => 1 } as any;
+    const tw = new TwiddleTree(null,null,null);
+    const polys = [new DummyPoly(1),new DummyPoly(2),new DummyPoly(3),new DummyPoly(4)];
+    const sp = new SecureCirclePoly(polys as any);
+    const orig = DummyPoly.prototype.evaluateWithTwiddles;
+    const seen:any[] = [];
+    DummyPoly.prototype.evaluateWithTwiddles = function(d,t){ seen.push(this.v); return { values:[this.v] }; };
+    expect(() => sp.evaluateWithTwiddles(domain, tw)).toThrow('SecureEvaluation: size mismatch');
+    DummyPoly.prototype.evaluateWithTwiddles = orig;
+    expect(seen).toEqual([1,2,3,4]);
+  });
 });


### PR DESCRIPTION
## Summary
- expand core field tests for error paths and utils
- add comprehensive coverage for M31 complex conjugate
- test additional QM31 helpers
- cover more of line/circle domain and canonic coset
- ensure SecureCirclePoly delegates twiddle evaluation

## Testing
- `bun run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `bun run test`