### PR TITLE
[core] add peekable utils and tests

### DIFF
--- a/packages/core/src/vcs/utils.ts
+++ b/packages/core/src/vcs/utils.ts
@@ -1,3 +1,72 @@
+export interface PeekableIterator<T> extends Iterator<T>, Iterable<T> {
+  peek(): T | undefined;
+}
+
+/**
+ * Creates a simple peekable iterator from any iterable.
+ */
+export function makePeekable<T>(iterable: Iterable<T>): PeekableIterator<T> {
+  const iterator = iterable[Symbol.iterator]();
+  let peeked: IteratorResult<T> | null = null;
+  const peekable: PeekableIterator<T> = {
+    next() {
+      if (peeked) {
+        const result = peeked;
+        peeked = null;
+        return result;
+      }
+      return iterator.next();
+    },
+    peek() {
+      if (peeked === null) {
+        peeked = iterator.next();
+      }
+      return peeked.done ? undefined : peeked.value;
+    },
+    [Symbol.iterator]() {
+      return this;
+    },
+  };
+  return peekable;
+}
+
+/**
+ * Fetches the next node that needs to be decommited in the current Merkle layer.
+ *
+ * Port of `vcs/utils.rs` function `next_decommitment_node`.
+ * See original Rust reference below for edge-case behavior.
+ */
+export function nextDecommitmentNode(
+  prevQueries: PeekableIterator<number>,
+  layerQueries: PeekableIterator<number>,
+): number | undefined {
+  const candidates: number[] = [];
+  const p = prevQueries.peek();
+  if (p !== undefined) {
+    candidates.push(Math.floor(p / 2));
+  }
+  const l = layerQueries.peek();
+  if (l !== undefined) {
+    candidates.push(l);
+  }
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  return Math.min(...candidates);
+}
+
+/**
+ * Helper that converts an optional iterable into a peekable iterator.
+ *
+ * Port of `vcs/utils.rs` function `option_flatten_peekable`.
+ * See original Rust reference below for edge-case behavior.
+ */
+export function optionFlattenPeekable(
+  a?: Iterable<number> | null,
+): PeekableIterator<number> {
+  return makePeekable(a ?? []);
+}
+
 /*
 This is the Rust code from vcs/utils.rs that needs to be ported to Typescript in this vcs/utils.ts file:
 ```rs

--- a/packages/core/test/vcs/utils.test.ts
+++ b/packages/core/test/vcs/utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { makePeekable, nextDecommitmentNode, optionFlattenPeekable } from "../../src/vcs/utils";
+
+describe("optionFlattenPeekable", () => {
+  it("creates empty iterator when option is undefined", () => {
+    const it = optionFlattenPeekable();
+    expect(it.peek()).toBeUndefined();
+    expect(it.next().done).toBe(true);
+  });
+
+  it("iterates through provided values", () => {
+    const it = optionFlattenPeekable([1, 2]);
+    expect(it.peek()).toBe(1);
+    expect(it.next().value).toBe(1);
+    expect(it.peek()).toBe(2);
+    expect(it.next().value).toBe(2);
+    expect(it.peek()).toBeUndefined();
+  });
+});
+
+describe("nextDecommitmentNode", () => {
+  const make = (a: number[], b: number[]) => [makePeekable(a), makePeekable(b)] as const;
+
+  it("returns smallest candidate", () => {
+    const [prev, layer] = make([4, 6], [5, 8]);
+    expect(nextDecommitmentNode(prev, layer)).toBe(2); // from prev 4 -> 2
+  });
+
+  it("handles empty prev queries", () => {
+    const [prev, layer] = make([], [3, 4]);
+    expect(nextDecommitmentNode(prev, layer)).toBe(3);
+  });
+
+  it("returns undefined when both empty", () => {
+    const [prev, layer] = make([], []);
+    expect(nextDecommitmentNode(prev, layer)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement `nextDecommitmentNode` and helper iterators in `vcs/utils.ts`
- add accompanying unit tests for the new utilities

## Testing
- `bun test`
- `bun run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*