### PR TITLE
[core] port circle geometry

### DIFF
--- a/packages/core/src/circle.ts
+++ b/packages/core/src/circle.ts
@@ -1,5 +1,302 @@
-// Circle implementation
-console.log("circle.ts"); 
+import type { Field, FieldExpOps, ComplexConjugate } from "./fields/fields";
+import { M31 } from "./fields/m31";
+import { QM31 as SecureField, P4 } from "./fields/qm31";
+
+/**
+ * Minimal interface for a randomness channel capable of drawing a `SecureField`.
+ * The real channel implementations are not yet ported but `get_random_point`
+ * relies on this functionality.
+ */
+export interface Channel {
+  draw_felt(): SecureField;
+}
+
+/**
+ * A point on the complex circle. Treated as an additive group.
+ *
+ * Port of `circle.rs` struct `CirclePoint`.
+ */
+export class CirclePoint<F extends Field<F>> implements ComplexConjugate<CirclePoint<F>> {
+  constructor(public x: F, public y: F) {}
+
+  clone(): CirclePoint<F> {
+    return new CirclePoint(this.x.clone(), this.y.clone());
+  }
+
+  /** Construct the identity element using the provided field implementation. */
+  static zero<F extends Field<F>>(FClass: { one(): F; zero(): F }): CirclePoint<F> {
+    return new CirclePoint(FClass.one(), FClass.zero());
+  }
+
+  /** Additive doubling. */
+  double(): CirclePoint<F> {
+    return this.add(this);
+  }
+
+  /** Apply the circle's x-coordinate doubling map. */
+  static double_x<F extends Field<F>>(x: F, FClass: { one(): F }): F {
+    const sx = x.square();
+    return sx.clone().add(sx).sub(FClass.one());
+  }
+
+  /** Returns the log order of a point. All points have order `2^k`. */
+  log_order(this: CirclePoint<F>, FClass: { one(): F }): number {
+    let res = 0;
+    let cur = this.x.clone();
+    while (!cur.equals(FClass.one())) {
+      cur = CirclePoint.double_x(cur, FClass);
+      res += 1;
+    }
+    return res;
+  }
+
+  /** Multiply the point by a scalar using double and add. */
+  mul(this: CirclePoint<F>, scalar: bigint, FClass: { one(): F; zero(): F }): CirclePoint<F> {
+    let res = CirclePoint.zero(FClass);
+    let cur = this.clone();
+    let s = BigInt(scalar);
+    while (s > 0n) {
+      if (s & 1n) {
+        res = res.add(cur);
+      }
+      cur = cur.double();
+      s >>= 1n;
+    }
+    return res;
+  }
+
+  /** Repeatedly doubles the point n times. */
+  repeated_double(this: CirclePoint<F>, n: number): CirclePoint<F> {
+    let res = this.clone();
+    for (let i = 0; i < n; i++) {
+      res = res.double();
+    }
+    return res;
+  }
+
+  conjugate(): CirclePoint<F> {
+    return new CirclePoint(this.x.clone(), this.y.neg());
+  }
+
+  antipode(): CirclePoint<F> {
+    return new CirclePoint(this.x.neg(), this.y.neg());
+  }
+
+  intoEf<EF>(convert: (v: F) => EF): CirclePoint<EF> {
+    return new CirclePoint(convert(this.x), convert(this.y));
+  }
+
+  mul_signed(this: CirclePoint<F>, off: number, FClass: { one(): F; zero(): F }): CirclePoint<F> {
+    if (off >= 0) {
+      return this.mul(BigInt(off), FClass);
+    } else {
+      return this.conjugate().mul(BigInt(-off), FClass);
+    }
+  }
+
+  add(rhs: CirclePoint<F>): CirclePoint<F> {
+    const x = this.x.clone().mul(rhs.x).sub(this.y.clone().mul(rhs.y));
+    const y = this.x.mul(rhs.y).add(this.y.mul(rhs.x));
+    return new CirclePoint(x, y);
+  }
+
+  neg(): CirclePoint<F> {
+    return this.conjugate();
+  }
+
+  sub(rhs: CirclePoint<F>): CirclePoint<F> {
+    return this.add(rhs.neg());
+  }
+
+  complexConjugate(): CirclePoint<F> {
+    return new CirclePoint(this.x.complexConjugate(), this.y.complexConjugate());
+  }
+
+  /** Return the SecureField point at the given index. */
+  static get_point(index: bigint): CirclePoint<SecureField> {
+    if (index >= SECURE_FIELD_CIRCLE_ORDER) throw new Error("index out of range");
+    return SECURE_FIELD_CIRCLE_GEN.mul(index, SecureField);
+  }
+
+  /** Draw a random SecureField circle point from a channel. */
+  static get_random_point(channel: Channel): CirclePoint<SecureField> {
+    const t = channel.draw_felt();
+    const t_square = t.square();
+    const one_plus_tsquared_inv = t_square.add(SecureField.one()).inverse();
+    const x = SecureField.one().add(t_square.neg()).mul(one_plus_tsquared_inv);
+    const y = t.double().mul(one_plus_tsquared_inv);
+    return new CirclePoint(x, y);
+  }
+}
+
+/** Generator for the circle group over {@link M31}. */
+export const M31_CIRCLE_GEN = new CirclePoint(M31.fromUnchecked(2), M31.fromUnchecked(1268011823));
+
+/** Log order of {@link M31_CIRCLE_GEN}. */
+export const M31_CIRCLE_LOG_ORDER = 31;
+
+/** Generator for the circle group over {@link SecureField}. */
+export const SECURE_FIELD_CIRCLE_GEN = new CirclePoint(
+  SecureField.fromUnchecked(1, 0, 478637715, 513582971),
+  SecureField.fromUnchecked(992285211, 649143431, 740191619, 1186584352)
+);
+
+/** Order of {@link SECURE_FIELD_CIRCLE_GEN}. */
+export const SECURE_FIELD_CIRCLE_ORDER = BigInt(P4) - 1n;
+
+/** Integer representing the circle point `i * CIRCLE_GEN`. */
+export class CirclePointIndex {
+  constructor(public value: number) {}
+
+  static zero(): CirclePointIndex {
+    return new CirclePointIndex(0);
+  }
+
+  static generator(): CirclePointIndex {
+    return new CirclePointIndex(1);
+  }
+
+  reduce(): CirclePointIndex {
+    return new CirclePointIndex(this.value & ((1 << M31_CIRCLE_LOG_ORDER) - 1));
+  }
+
+  static subgroup_gen(logSize: number): CirclePointIndex {
+    if (logSize > M31_CIRCLE_LOG_ORDER) throw new Error("log_size too large");
+    return new CirclePointIndex(1 << (M31_CIRCLE_LOG_ORDER - logSize));
+  }
+
+  to_point(): CirclePoint<M31> {
+    return M31_CIRCLE_GEN.mul(BigInt(this.value), M31);
+  }
+
+  half(): CirclePointIndex {
+    if (this.value & 1) throw new Error("not even");
+    return new CirclePointIndex(this.value >> 1);
+  }
+
+  add(rhs: CirclePointIndex): CirclePointIndex {
+    return new CirclePointIndex(this.value + rhs.value).reduce();
+  }
+
+  sub(rhs: CirclePointIndex): CirclePointIndex {
+    return new CirclePointIndex(this.value + (1 << M31_CIRCLE_LOG_ORDER) - rhs.value).reduce();
+  }
+
+  mul(rhs: number): CirclePointIndex {
+    return new CirclePointIndex(Math.imul(this.value, rhs)).reduce();
+  }
+
+  neg(): CirclePointIndex {
+    return new CirclePointIndex((1 << M31_CIRCLE_LOG_ORDER) - this.value).reduce();
+  }
+}
+
+/** Represents the coset `initial + <step>`. */
+export class Coset {
+  constructor(
+    public initial_index: CirclePointIndex,
+    public log_size: number,
+  ) {
+    if (log_size > M31_CIRCLE_LOG_ORDER) throw new Error("log_size too large");
+    this.initial_index = initial_index;
+    this.log_size = log_size;
+    const step_size = CirclePointIndex.subgroup_gen(log_size);
+    this.step_size = step_size;
+    this.step = step_size.to_point();
+    this.initial = initial_index.to_point();
+  }
+
+  initial: CirclePoint<M31>;
+  step_size: CirclePointIndex;
+  step: CirclePoint<M31>;
+
+  static new(initial_index: CirclePointIndex, log_size: number): Coset {
+    return new Coset(initial_index, log_size);
+  }
+
+  /** Creates a coset of the form `<G_n>`. */
+  static subgroup(log_size: number): Coset {
+    return Coset.new(CirclePointIndex.zero(), log_size);
+  }
+
+  /** Creates a coset of the form `G_2n + <G_n>`. */
+  static odds(log_size: number): Coset {
+    return Coset.new(CirclePointIndex.subgroup_gen(log_size + 1), log_size);
+  }
+
+  /** Creates a coset of the form `G_4n + <G_n>`. */
+  static half_odds(log_size: number): Coset {
+    return Coset.new(CirclePointIndex.subgroup_gen(log_size + 2), log_size);
+  }
+
+  size(): number {
+    return 1 << this.log_size;
+  }
+
+  iter(): CosetIterator<CirclePoint<M31>> {
+    return new CosetIterator(this.initial, this.step, this.size());
+  }
+
+  iter_indices(): CosetIterator<CirclePointIndex> {
+    return new CosetIterator(this.initial_index, this.step_size, this.size());
+  }
+
+  double(): Coset {
+    if (this.log_size <= 0) throw new Error("log_size must be >0 to double");
+    return new Coset(this.initial_index.mul(2), this.log_size - 1);
+  }
+
+  repeated_double(n: number): Coset {
+    let c: Coset = this;
+    for (let i = 0; i < n; i++) c = c.double();
+    return c;
+  }
+
+  is_doubling_of(other: Coset): boolean {
+    return this.log_size <= other.log_size && this.equals(other.repeated_double(other.log_size - this.log_size));
+  }
+
+  equals(other: Coset): boolean {
+    return (
+      this.initial_index.value === other.initial_index.value &&
+      this.step_size.value === other.step_size.value &&
+      this.log_size === other.log_size
+    );
+  }
+
+  index_at(index: number): CirclePointIndex {
+    return this.initial_index.add(this.step_size.mul(index));
+  }
+
+  at(index: number): CirclePoint<M31> {
+    return this.index_at(index).to_point();
+  }
+
+  shift(shift_size: CirclePointIndex): Coset {
+    return Coset.new(this.initial_index.add(shift_size), this.log_size);
+  }
+
+  conjugate(): Coset {
+    return Coset.new(this.initial_index.neg(), this.log_size);
+  }
+}
+
+export class CosetIterator<T> implements IterableIterator<T> {
+  constructor(public cur: T, public step: T, public remaining: number) {}
+
+  next(): IteratorResult<T> {
+    if (this.remaining === 0) return { done: true, value: undefined as any };
+    this.remaining -= 1;
+    const res = this.cur;
+    // @ts-ignore - relies on add method presence
+    this.cur = this.cur.add(this.step);
+    return { done: false, value: res };
+  }
+
+  [Symbol.iterator](): IterableIterator<T> {
+    return this;
+  }
+}
 
 /*
 This is the Rust code from circle.rs that needs to be ported to Typescript in this circle.ts file:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export const sum = (a: number, b: number): number => {
 
 // Expose the polynomial utilities as part of the public API
 export * from "./poly";
+export * from "./circle";
 
 /*
 This is the Rust code from mod.rs that needs to be ported to Typescript in this index.ts file:

--- a/packages/core/src/poly/circle/canonic.ts
+++ b/packages/core/src/poly/circle/canonic.ts
@@ -87,10 +87,7 @@ impl CanonicCoset {
 // structure where `CanonicCoset` provides convenience constructors for a
 // corresponding `CircleDomain`.
 import { CircleDomain } from "./domain";
-
-// TODO: import { Coset, CirclePoint, CirclePointIndex } from "../../circle";
-// These come from the yet-to-be-translated circle geometry module.
-
+import { Coset, CirclePoint, CirclePointIndex } from "../../circle";
 import type { M31 as BaseField } from "../../fields/m31";
 
 /** A coset of the form `G_{2n} + <G_n>` used for circle FFT domains. */

--- a/packages/core/src/poly/circle/domain.ts
+++ b/packages/core/src/poly/circle/domain.ts
@@ -183,13 +183,9 @@ mod tests {
 ```
 */
 
-// TODO: import { Coset } from "../../circle";
-// TODO: import { CirclePoint, CirclePointIndex } from "../../circle";
-// TODO: import { M31_CIRCLE_LOG_ORDER } from "../../circle";
-// Once the circle geometry module is implemented, update these imports.
+import { Coset, CirclePoint, CirclePointIndex, M31_CIRCLE_LOG_ORDER } from "../../circle";
 
-// Placeholder constant until circle constants are ported.
-export const MAX_CIRCLE_DOMAIN_LOG_SIZE = 0; // M31_CIRCLE_LOG_ORDER - 1
+export const MAX_CIRCLE_DOMAIN_LOG_SIZE = M31_CIRCLE_LOG_ORDER - 1;
 
 /** A valid domain for circle polynomial interpolation and evaluation. */
 export class CircleDomain {

--- a/packages/core/src/poly/circle/ops.ts
+++ b/packages/core/src/poly/circle/ops.ts
@@ -73,11 +73,8 @@ pub trait PolyOps: ColumnOps<BaseField> + Sized {
 ```
 */
 
-// TODO: import type { CirclePoint, Coset } from "../../circle";
-// Once the circle geometry module is ported, update these imports and ensure the
-// types match the Rust definitions.
-
-// TODO: import type { SecureField } from "../../fields/qm31";
+import type { CirclePoint, Coset } from "../../circle";
+import type { SecureField } from "../../fields/qm31";
 // Once the secure field implementation is available, replace `unknown` with
 // `SecureField`.
 

--- a/packages/core/test/circle/circle.test.ts
+++ b/packages/core/test/circle/circle.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { CirclePoint, CirclePointIndex, Coset, SECURE_FIELD_CIRCLE_GEN, SECURE_FIELD_CIRCLE_ORDER } from "../../src/circle";
+import { QM31 as SecureField } from "../../src/fields/qm31";
+
+class DummyChannel {
+  private c = 1;
+  draw_felt(): SecureField {
+    const val = this.c++;
+    return SecureField.fromUnchecked(val, val + 1, val + 2, val + 3);
+  }
+}
+
+describe("Coset iteration", () => {
+  it("produces expected indices and points", () => {
+    const coset = Coset.new(new CirclePointIndex(1), 3);
+    const actualIndices = Array.from(coset.iter_indices()).map(i => i.value);
+    const step = CirclePointIndex.subgroup_gen(3);
+    const expectedIndices = Array.from({length: 8}, (_,i)=> new CirclePointIndex(1).add(step.mul(i)).value);
+    expect(actualIndices).toEqual(expectedIndices);
+
+    const actualPoints = Array.from(coset.iter()).map(p=>p.x.value);
+    const expectedPoints = expectedIndices.map(v => new CirclePointIndex(v).to_point().x.value);
+    expect(actualPoints).toEqual(expectedPoints);
+  });
+});
+
+describe("Coset splitting", () => {
+  it("half coset and its conjugate partition odds", () => {
+    const logSize = 5;
+    const coset = Coset.odds(logSize);
+    const half = Coset.half_odds(logSize - 1);
+    const conj = half.conjugate();
+    const toKey = (p: any) => `${p.x.value},${p.y.value}`;
+    const setHalf = new Set(Array.from(half.iter()).map(toKey));
+    const setConj = new Set(Array.from(conj.iter()).map(toKey));
+    expect([...setHalf].filter(x=>setConj.has(x)).length).toBe(0);
+    const union = new Set([...setHalf, ...setConj]);
+    const full = new Set(Array.from(coset.iter()).map(toKey));
+    expect(union).toEqual(full);
+  });
+});
+
+describe("CirclePoint utilities", () => {
+  it("get_random_point draws different points", () => {
+    const channel = new DummyChannel();
+    const first = CirclePoint.get_random_point(channel);
+    const second = CirclePoint.get_random_point(channel);
+    expect(first.x.equals(second.x)).toBe(false);
+  });
+
+  it("secure field generator has correct order", () => {
+    const sum = SECURE_FIELD_CIRCLE_GEN.mul(SECURE_FIELD_CIRCLE_ORDER, SecureField);
+    const zero = CirclePoint.zero(SecureField);
+    expect(sum.x.equals(zero.x)).toBe(true);
+    expect(sum.y.equals(zero.y)).toBe(true);
+    const lhs = SECURE_FIELD_CIRCLE_GEN.x.square().add(SECURE_FIELD_CIRCLE_GEN.y.square());
+    expect(lhs.equals(SecureField.one())).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- port circle geometry from Rust, implementing `CirclePoint`, `CirclePointIndex`, `Coset` and iterators
- wire up circle exports and update dependent modules
- add unit tests for circle operations

## Testing
- `bun test`