### PR TITLE
[core] implement basic FRI config and cpu accumulation

### DIFF
--- a/packages/core/src/backend/cpu/accumulation.ts
+++ b/packages/core/src/backend/cpu/accumulation.ts
@@ -61,3 +61,36 @@ mod tests {
 }
 ```
 */
+import { QM31 as SecureField } from "../../fields/qm31";
+import { SecureColumnByCoords } from "../../fields/secure_columns";
+
+/**
+ * Port of `backend/cpu/accumulation.rs` AccumulationOps for CpuBackend.
+ * See original Rust reference above for edge-case behavior.
+ */
+export function accumulate(
+  column: SecureColumnByCoords,
+  other: SecureColumnByCoords,
+): void {
+  if (column.len() !== other.len()) {
+    throw new Error("column length mismatch");
+  }
+  for (let i = 0; i < column.len(); i++) {
+    const res = column.at(i).add(other.at(i));
+    column.set(i, res);
+  }
+}
+
+/** Generate the first `nPowers` powers of `felt`. */
+export function generate_secure_powers(
+  felt: SecureField,
+  nPowers: number,
+): SecureField[] {
+  const res: SecureField[] = [];
+  let acc = SecureField.one();
+  for (let i = 0; i < nPowers; i++) {
+    res.push(acc);
+    acc = acc.mul(felt);
+  }
+  return res;
+}

--- a/packages/core/test/backend/accumulation.test.ts
+++ b/packages/core/test/backend/accumulation.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { generate_secure_powers, accumulate } from "../../src/backend/cpu/accumulation";
+import { QM31 } from "../../src/fields/qm31";
+import { SecureColumnByCoords } from "../../src/fields/secure_columns";
+
+function qm31(a:number,b:number,c:number,d:number): QM31 {
+  return QM31.fromUnchecked(a,b,c,d);
+}
+
+describe("CpuBackend accumulation", () => {
+  it("generate_secure_powers works", () => {
+    const felt = qm31(1,2,3,4);
+    const powers = generate_secure_powers(felt, 10);
+    expect(powers.length).toBe(10);
+    expect(powers[0].equals(QM31.one())).toBe(true);
+    expect(powers[1].equals(felt)).toBe(true);
+    expect(powers[7].equals(felt.pow(7))).toBe(true);
+  });
+
+  it("generate_secure_powers empty", () => {
+    const felt = qm31(1,2,3,4);
+    expect(generate_secure_powers(felt, 0)).toEqual([]);
+  });
+
+  it("accumulate adds columns elementwise", () => {
+    const a = SecureColumnByCoords.from([qm31(1,1,1,1), qm31(2,2,2,2)]);
+    const b = SecureColumnByCoords.from([qm31(3,3,3,3), qm31(4,4,4,4)]);
+    const expected0 = a.at(0).add(b.at(0));
+    const expected1 = a.at(1).add(b.at(1));
+    accumulate(a, b);
+    expect(a.at(0).equals(expected0)).toBe(true);
+    expect(a.at(1).equals(expected1)).toBe(true);
+  });
+});

--- a/packages/core/test/fri/fri_config.test.ts
+++ b/packages/core/test/fri/fri_config.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { FriConfig } from "../../src/fri";
+
+describe("FriConfig", () => {
+  it("constructs with valid parameters", () => {
+    const cfg = new FriConfig(2, 4, 3);
+    expect(cfg.log_last_layer_degree_bound).toBe(2);
+    expect(cfg.log_blowup_factor).toBe(4);
+    expect(cfg.n_queries).toBe(3);
+    expect(cfg.last_layer_domain_size()).toBe(1 << (2 + 4));
+    expect(cfg.security_bits()).toBe(4 * 3);
+  });
+
+  it("throws on invalid parameters", () => {
+    expect(() => new FriConfig(11, 4, 1)).toThrow();
+    expect(() => new FriConfig(2, 0, 1)).toThrow();
+    expect(() => new FriConfig(2, 17, 1)).toThrow();
+  });
+});

--- a/porting_status.json
+++ b/porting_status.json
@@ -7,8 +7,8 @@
   "poly/circle/mod.rs": "packages/core/src/poly/circle/ (partial)",
   "circle.rs": "packages/core/src/circle.ts (partial)",
   "fft.rs": "packages/core/src/fft.ts (partial)",
-  "fri.rs": "packages/core/src/fri.ts (unstarted)",
+  "fri.rs": "packages/core/src/fri.ts (partial)",
   "constraints.rs": "packages/core/src/constraints.ts (unstarted)",
   "proof_of_work.rs": "packages/core/src/proof_of_work.ts (unstarted)",
-  "queries.rs": "packages/core/src/queries.ts (unstarted)"
+  "queries.rs": "packages/core/src/queries.ts (partial)"
 }


### PR DESCRIPTION
## Summary
- port partial FriConfig from fri.rs and expose helper utilities
- implement cpu backend accumulation helpers
- add unit tests for FriConfig and accumulation
- update porting status

## Testing
- `bun run lint`
- `bun run test`