### PR TITLE
[core] add cpu backend skeleton with bitReverse

### DIFF
--- a/packages/core/src/backend/cpu/README.md
+++ b/packages/core/src/backend/cpu/README.md
@@ -1,0 +1,39 @@
+# CPU Backend
+
+This directory hosts the TypeScript port of the original `backend/cpu` Rust
+module.  The CPU backend provides a reference implementation of various back-end
+traits used throughout the library such as Merkle hashing, polynomial
+manipulation and proof-of-work.  Many files currently expose only lightweight
+stubs – the commented Rust remains in place for future reference.
+
+```
+backend/cpu/
+├─ accumulation.ts
+├─ blake2.ts
+├─ circle.ts
+├─ fri.ts
+├─ grind.ts
+├─ index.ts
+└─ quotients.ts
+```
+
+The most functional component today is `index.ts`, exposing the `CpuBackend`
+class and `bitReverse` helper.  Bit reversal is commonly required when working
+with FFTs.  Given an array of eight elements the reordering performed by
+`bitReverse` is illustrated below:
+
+```
+index: 0 1 2 3 4 5 6 7
+rev:   0 4 2 6 1 5 3 7
+```
+
+```
+ before        after
++---+---+---+   +---+---+---+
+|0|1|2|3|   =>  |0|4|2|6|
+|4|5|6|7|        |1|5|3|7|
++---+---+---+   +---+---+---+
+```
+
+Further modules will be fleshed out as the port progresses.  Run `bun test` to
+execute the accompanying unit tests.

--- a/packages/core/src/backend/cpu/circle.ts
+++ b/packages/core/src/backend/cpu/circle.ts
@@ -371,3 +371,8 @@ mod tests {
 }
 ```
 */
+
+// TODO: port circle polynomial operations from Rust
+export function evaluateCircle(): never {
+  throw new Error("evaluateCircle not yet implemented");
+}

--- a/packages/core/src/backend/cpu/fri.ts
+++ b/packages/core/src/backend/cpu/fri.ts
@@ -147,3 +147,14 @@ mod tests {
 }
 ```
 */
+
+// TODO: translate fri.rs fully
+export function foldLine(): never {
+  throw new Error("foldLine not yet implemented");
+}
+export function foldCircleIntoLine(): never {
+  throw new Error("foldCircleIntoLine not yet implemented");
+}
+export function decompose(): never {
+  throw new Error("decompose not yet implemented");
+}

--- a/packages/core/src/backend/cpu/grind.ts
+++ b/packages/core/src/backend/cpu/grind.ts
@@ -20,3 +20,13 @@ impl<C: Channel> GrindOps<C> for CpuBackend {
 }
 ```
 */
+
+export function grind(channel: { mix_u64(n: number): void; trailing_zeros(): number }, powBits: number): number {
+  let nonce = 0;
+  while (true) {
+    const c = { ...channel } as any; // shallow clone
+    c.mix_u64(nonce);
+    if (c.trailing_zeros() >= powBits) return nonce;
+    nonce++;
+  }
+}

--- a/packages/core/src/backend/cpu/index.ts
+++ b/packages/core/src/backend/cpu/index.ts
@@ -124,3 +124,63 @@ mod tests {
 }
 ```
 */
+
+import { bitReverseIndex } from "../../utils";
+import type { Backend, Column, ColumnOps } from "../index";
+
+/**
+ * TypeScript implementation of the CpuBackend from `backend/cpu/mod.rs`.
+ */
+export class CpuBackend implements Backend {}
+
+/** In-place bit reverse. Mirrors the Rust function `bit_reverse`. */
+export function bitReverse<T>(arr: T[]): void {
+  const n = arr.length;
+  if (n === 0 || (n & (n - 1)) !== 0) {
+    throw new Error("length is not power of two");
+  }
+  const logN = Math.floor(Math.log2(n));
+  for (let i = 0; i < n; i++) {
+    const j = bitReverseIndex(i, logN);
+    if (j > i) {
+      const tmp = arr[i];
+      arr[i] = arr[j];
+      arr[j] = tmp;
+    }
+  }
+}
+
+export class CpuColumnOps<T> implements ColumnOps<T> {
+  bitReverseColumn(column: T[]): void {
+    bitReverse(column);
+  }
+}
+
+export class CpuColumn<T> implements Column<T> {
+  constructor(private data: T[]) {}
+
+  static zeros<T>(len: number, defaultValue: T): CpuColumn<T> {
+    return new CpuColumn(Array.from({ length: len }, () => defaultValue));
+  }
+
+  static uninitialized<T>(len: number): CpuColumn<T> {
+    return new CpuColumn(new Array(len).fill(undefined as unknown as T));
+  }
+
+  toCPU(): T[] {
+    return [...this.data];
+  }
+  len(): number {
+    return this.data.length;
+  }
+  at(index: number): T {
+    return this.data[index];
+  }
+  set(index: number, value: T): void {
+    this.data[index] = value;
+  }
+}
+
+export type CpuCirclePoly<F = unknown> = unknown; // TODO
+export type CpuCircleEvaluation<F = unknown, EvalOrder = unknown> = unknown; // TODO
+export type CpuMle<F> = unknown; // TODO

--- a/packages/core/src/backend/cpu/quotients.ts
+++ b/packages/core/src/backend/cpu/quotients.ts
@@ -194,3 +194,8 @@ mod tests {
 }
 ```
 */
+
+// TODO: translate quotient logic
+export function accumulateRowQuotients(): never {
+  throw new Error("accumulateRowQuotients not yet implemented");
+}

--- a/packages/core/src/backend/index.ts
+++ b/packages/core/src/backend/index.ts
@@ -1,0 +1,19 @@
+export interface Backend {}
+
+export interface BackendForChannel<C> {}
+
+export interface Column<T> {
+  /** Length of the column */
+  len(): number;
+  /** Get value at index */
+  at(index: number): T;
+  /** Set value at index */
+  set(index: number, value: T): void;
+  /** Convert the column into a plain CPU array */
+  toCPU(): T[];
+}
+
+export interface ColumnOps<T> {
+  /** Performs an in-place bit reverse on the column */
+  bitReverseColumn(column: T[]): void;
+}

--- a/packages/core/test/backend/bit_reverse.test.ts
+++ b/packages/core/test/backend/bit_reverse.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { bitReverse } from "../../src/backend/cpu";
+
+describe("bitReverse", () => {
+  it("reorders array in bit reversed order", () => {
+    const data = [0,1,2,3,4,5,6,7];
+    bitReverse(data);
+    expect(data).toEqual([0,4,2,6,1,5,3,7]);
+  });
+
+  it("throws on non power of two", () => {
+    expect(() => bitReverse([0,1,2])).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- implement basic backend interfaces
- add CpuBackend with bitReverse and column helpers
- sketch placeholder cpu backend modules
- add README overview for cpu backend
- include bitReverse tests

## Testing
- `bun test`