### PR TITLE
[core] implement constraints and PoW

### DIFF
--- a/packages/core/src/constraints.ts
+++ b/packages/core/src/constraints.ts
@@ -1,5 +1,5 @@
 // Constraints implementation
-console.log("constraints.ts"); 
+
 
 /*
 This is the Rust code from constraints.rs that needs to be ported to Typescript in this constraints.ts file:
@@ -256,3 +256,133 @@ mod tests {
 }
 ```
 */
+// -------------------- TypeScript implementation --------------------
+import { CirclePoint, Coset } from "./circle";
+import { M31 } from "./fields/m31";
+import { QM31 as SecureField } from "./fields/qm31";
+import type { ExtensionOf, Field } from "./fields/fields";
+import type { PointSample } from "./pcs/quotients";
+
+function convertBase<F>(FClass: any, v: M31): F {
+  if (FClass === M31) {
+    // M31.from accepts number
+    return FClass.from(v.value);
+  }
+  if (typeof FClass.from === "function") {
+    return FClass.from(v);
+  }
+  if (typeof FClass.fromUnchecked === "function") {
+    return FClass.fromUnchecked(v.value);
+  }
+  return v as unknown as F;
+}
+
+function addBase<F>(x: any, v: M31, FClass: any): F {
+  if (typeof x.addM31 === "function") return x.addM31(v);
+  return x.add(convertBase<F>(FClass, v));
+}
+
+function subBase<F>(x: any, v: M31, FClass: any): F {
+  if (typeof x.subM31 === "function") return x.subM31(v);
+  return x.sub(convertBase<F>(FClass, v));
+}
+
+/**
+ * Port of `constraints.rs` function `coset_vanishing`.
+ */
+export function cosetVanishing<F extends Field<F>>(
+  coset: Coset,
+  p: CirclePoint<F>,
+  FClass: { one(): F; from(v: any): F; fromUnchecked?: (n: number) => F }
+): F {
+  const half = coset.step_size.half().to_point();
+  const convert = (v: M31) => convertBase<F>(FClass, v);
+  const shifted = p
+    .sub(coset.initial.intoEf(convert))
+    .add(half.intoEf(convert));
+  let x = shifted.x;
+  for (let i = 1; i < coset.log_size; i++) {
+    x = CirclePoint.double_x(x, FClass);
+  }
+  return x;
+}
+
+/**
+ * Port of `constraints.rs` function `point_excluder`.
+ */
+export function pointExcluder<F extends Field<F>>(
+  excluded: CirclePoint<M31>,
+  p: CirclePoint<F>,
+  FClass: { one(): F; from(v: any): F; fromUnchecked?: (n: number) => F }
+): F {
+  const convert = (v: M31) => convertBase<F>(FClass, v);
+  const diff = p.sub(excluded.intoEf(convert));
+  return diff.x.sub(convert(M31.one()));
+}
+
+/**
+ * Port of `constraints.rs` function `pair_vanishing`.
+ */
+export function pairVanishing<F extends Field<F>>(
+  excluded0: CirclePoint<F>,
+  excluded1: CirclePoint<F>,
+  p: CirclePoint<F>
+): F {
+  return excluded0.y
+    .sub(excluded1.y)
+    .mul(p.x)
+    .add(
+      excluded1.x
+        .sub(excluded0.x)
+        .mul(p.y)
+        .add(excluded0.x.mul(excluded1.y).sub(excluded0.y.mul(excluded1.x)))
+    );
+}
+
+/**
+ * Port of `constraints.rs` function `point_vanishing`.
+ */
+export function pointVanishing<F extends Field<F>, EF extends Field<EF>>(
+  vanishPoint: CirclePoint<F>,
+  p: CirclePoint<EF>,
+  convert: (v: F) => EF,
+  EFClass: { one(): EF }
+): EF {
+  const diff = p.sub(vanishPoint.intoEf(convert));
+  const denom = EFClass.one().add(diff.x).inverse();
+  return diff.y.mul(denom);
+}
+
+/**
+ * Port of `constraints.rs` function `complex_conjugate_line`.
+ */
+export function complexConjugateLine(
+  point: CirclePoint<SecureField>,
+  value: SecureField,
+  p: CirclePoint<M31>
+): SecureField {
+  if (point.y.equals(point.y.complexConjugate())) {
+    throw new Error("Cannot evaluate a line with a single point");
+  }
+  const diff = SecureField.from(p.y).sub(point.y);
+  const numerator = value.complexConjugate().sub(value).mul(diff);
+  const denom = point.complexConjugate().y.sub(point.y).inverse();
+  return value.add(numerator.mul(denom));
+}
+
+/**
+ * Port of `constraints.rs` function `complex_conjugate_line_coeffs`.
+ */
+export function complexConjugateLineCoeffs(
+  sample: PointSample,
+  alpha: SecureField
+): [SecureField, SecureField, SecureField] {
+  if (sample.point.y.equals(sample.point.y.complexConjugate())) {
+    throw new Error("Cannot evaluate a line with a single point");
+  }
+  const a = sample.value.complexConjugate().sub(sample.value);
+  const c = sample.point.complexConjugate().y.sub(sample.point.y);
+  const b = sample.value.mul(c).sub(a.mul(sample.point.y));
+  return [alpha.mul(a), alpha.mul(b), alpha.mul(c)];
+}
+

--- a/packages/core/src/proof_of_work.ts
+++ b/packages/core/src/proof_of_work.ts
@@ -1,5 +1,4 @@
 // Proof of work implementation
-console.log("proof_of_work.ts"); 
 
 /*
 This is the Rust code from proof_of_work.rs that needs to be ported to Typescript in this proof_of_work.ts file:
@@ -13,3 +12,14 @@ pub trait GrindOps<C: Channel> {
 }
 ```
 */
+// -------------------- TypeScript implementation --------------------
+
+/**
+ * Port of `proof_of_work.rs` trait `GrindOps`.
+ * Implementers provide a `grind` function that searches for a nonce such
+ * that mixing it into the channel yields a digest with `powBits` leading zeros.
+ */
+export interface GrindOps<C> {
+  grind(channel: C, powBits: number): number;
+}
+

--- a/packages/core/test/constraints.test.ts
+++ b/packages/core/test/constraints.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { cosetVanishing, pointExcluder, pairVanishing, pointVanishing } from "../src/constraints";
+import { Coset, CirclePointIndex } from "../src/circle";
+import { M31 } from "../src/fields/m31";
+
+const F = M31;
+
+function isZero(f: M31) {
+  return f.isZero();
+}
+
+describe("cosetVanishing", () => {
+  it("vanishes on coset elements and not on others", () => {
+    const cosets = [
+      Coset.half_odds(5),
+      Coset.odds(5),
+      Coset.new(CirclePointIndex.zero(), 5),
+      Coset.half_odds(5).conjugate(),
+    ];
+    for (const c0 of cosets) {
+      for (const el of c0.iter()) {
+        expect(isZero(cosetVanishing(c0, el, F))).toBe(true);
+        for (const c1 of cosets) {
+          if (c1 === c0) continue;
+          expect(isZero(cosetVanishing(c1, el, F))).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe("pointExcluder", () => {
+  it("matches expected relation", () => {
+    const excluded = Coset.half_odds(5).at(10);
+    const point = CirclePointIndex.generator().mul(4).to_point();
+    const num = pointExcluder(excluded, point, F).mul(
+      pointExcluder(excluded.conjugate(), point, F)
+    );
+    const denom = point.x.sub(excluded.x).pow(2);
+    expect(num.equals(denom)).toBe(true);
+  });
+});
+
+describe("pairVanishing", () => {
+  it("vanishes at excluded points", () => {
+    const e0 = Coset.half_odds(5).at(10);
+    const e1 = Coset.half_odds(5).at(13);
+    const point = CirclePointIndex.generator().mul(4).to_point();
+    expect(pairVanishing(e0, e1, point).isZero()).toBe(false);
+    expect(pairVanishing(e0, e1, e0).isZero()).toBe(true);
+    expect(pairVanishing(e0, e1, e1).isZero()).toBe(true);
+  });
+});
+
+describe("pointVanishing", () => {
+  it("vanishes on given point except antipode", () => {
+    const coset = Coset.odds(5);
+    const vanish = coset.at(2);
+    for (const el of coset.iter()) {
+      if (el.x.equals(vanish.x) && el.y.equals(vanish.y)) {
+        expect(pointVanishing(vanish, el, x => x, F).isZero()).toBe(true);
+        continue;
+      }
+      if (el.x.equals(vanish.antipode().x) && el.y.equals(vanish.antipode().y)) {
+        continue;
+      }
+      expect(pointVanishing(vanish, el, x => x, F).isZero()).toBe(false);
+    }
+  });
+
+  it("fails on antipode", () => {
+    const coset = Coset.half_odds(6);
+    const point = coset.at(4);
+    expect(() => pointVanishing(point, point.antipode(), x => x, F)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- port constraints module from Rust to TypeScript
- port proof-of-work GrindOps trait
- add unit tests for constraint utilities

## Testing
- `bun test packages/core/test/constraints.test.ts`