### PR TITLE
[core] add blake2 channel and hashing

### DIFF
--- a/packages/core/src/channel/blake2.ts
+++ b/packages/core/src/channel/blake2.ts
@@ -226,3 +226,101 @@ mod tests {
 }
 ```
 */
+import { M31, P, N_BYTES_FELT } from '../fields/m31';
+import { QM31 as SecureField, SECURE_EXTENSION_DEGREE } from '../fields/qm31';
+import { Blake2sHash, Blake2sHasher } from '../vcs/blake2_hash';
+import { Channel, ChannelTime } from './index';
+
+export const BLAKE_BYTES_PER_HASH = 32;
+export const FELTS_PER_HASH = 8;
+
+export class Blake2sChannel implements Channel {
+  readonly BYTES_PER_HASH = BLAKE_BYTES_PER_HASH;
+  private digest: Blake2sHash = new Blake2sHash();
+  public channel_time: ChannelTime = new ChannelTime();
+  private baseQueue: M31[] = [];
+
+  private updateDigest(newDigest: Blake2sHash): void {
+    this.digest = newDigest;
+    this.channel_time.inc_challenges();
+  }
+
+  digestBytes(): Uint8Array { return this.digest.asBytes(); }
+
+  trailing_zeros(): number {
+    let val = 0n;
+    const bytes = this.digest.bytes;
+    for (let i = 15; i >= 0; i--) {
+      val = (val << 8n) | BigInt(bytes[i]);
+    }
+    let tz = 0;
+    while (((val >> BigInt(tz)) & 1n) === 0n && tz < 128) tz++;
+    return tz;
+  }
+
+  mix_felts(felts: readonly SecureField[]): void {
+    const hasher = new Blake2sHasher();
+    hasher.update(this.digest.bytes);
+    hasher.update(SecureField.intoSlice(felts as SecureField[]));
+    this.updateDigest(hasher.finalize());
+  }
+
+  mix_u32s(data: readonly number[]): void {
+    const hasher = new Blake2sHasher();
+    hasher.update(this.digest.bytes);
+    const buf = new Uint8Array(4);
+    const view = new DataView(buf.buffer);
+    for (const word of data) {
+      view.setUint32(0, word >>> 0, true);
+      hasher.update(buf);
+    }
+    this.updateDigest(hasher.finalize());
+  }
+
+  mix_u64(value: number): void {
+    const low = value >>> 0;
+    const high = Math.floor(value / 2 ** 32) >>> 0;
+    this.mix_u32s([low, high]);
+  }
+
+  private draw_base_felts(): M31[] {
+    while (true) {
+      const bytes = this.draw_random_bytes();
+      const u32s: number[] = [];
+      for (let i = 0; i < FELTS_PER_HASH; i++) {
+        const view = new DataView(bytes.buffer, i * N_BYTES_FELT, N_BYTES_FELT);
+        u32s.push(view.getUint32(0, true));
+      }
+      if (u32s.every((x) => x < 2 * P)) {
+        return u32s.map((x) => M31.reduce(x));
+      }
+    }
+  }
+
+  draw_felt(): SecureField {
+    if (this.baseQueue.length < SECURE_EXTENSION_DEGREE) {
+      this.baseQueue.push(...this.draw_base_felts());
+    }
+    const arr = this.baseQueue.splice(0, SECURE_EXTENSION_DEGREE) as [M31, M31, M31, M31];
+    return SecureField.fromM31Array(arr);
+  }
+
+  draw_felts(n_felts: number): SecureField[] {
+    const res: SecureField[] = [];
+    for (let i = 0; i < n_felts; i++) {
+      res.push(this.draw_felt());
+    }
+    return res;
+  }
+
+  draw_random_bytes(): Uint8Array {
+    const counter = new Uint8Array(BLAKE_BYTES_PER_HASH);
+    const view = new DataView(counter.buffer);
+    view.setUint32(0, this.channel_time.n_sent, true);
+    const input = new Uint8Array(this.digest.bytes.length + counter.length);
+    input.set(this.digest.bytes, 0);
+    input.set(counter, this.digest.bytes.length);
+    this.channel_time.inc_sent();
+    return Blake2sHasher.hash(input).asBytes();
+  }
+}

--- a/packages/core/src/channel/index.ts
+++ b/packages/core/src/channel/index.ts
@@ -60,3 +60,45 @@ pub trait MerkleChannel: Default {
 }
 ```
 */
+import type { QM31 as SecureField } from '../fields/qm31';
+import type { MerkleHasher } from '../vcs/ops';
+
+export { Blake2sChannel } from './blake2';
+// TODO: export Poseidon252Channel when implemented
+
+export const EXTENSION_FELTS_PER_HASH = 2;
+
+/**
+ * Tracks the time spent sending and receiving data through the channel.
+ */
+export class ChannelTime {
+  n_challenges = 0;
+  n_sent = 0;
+  inc_sent(): void {
+    this.n_sent += 1;
+  }
+  inc_challenges(): void {
+    this.n_challenges += 1;
+    this.n_sent = 0;
+  }
+}
+
+/** Interface for a random oracle channel. */
+export interface Channel {
+  readonly BYTES_PER_HASH: number;
+
+  trailing_zeros(): number;
+
+  mix_u32s(data: readonly number[]): void;
+  mix_felts(felts: readonly SecureField[]): void;
+  mix_u64(value: number): void;
+
+  draw_felt(): SecureField;
+  draw_felts(n_felts: number): SecureField[];
+  draw_random_bytes(): Uint8Array;
+}
+
+/** Interface for Merkle based channels. */
+export interface MerkleChannel<Hash> {
+  mix_root(channel: Channel, root: Hash): void;
+}

--- a/packages/core/src/vcs/hash.ts
+++ b/packages/core/src/vcs/hash.ts
@@ -20,3 +20,15 @@ pub trait Hash:
 }
 ```
 */
+/**
+ * Base interface for hash objects.
+ *
+ * Port of `vcs/hash.rs` trait `Hash`.
+ * See original Rust reference above for trait bounds.
+ */
+export interface HashLike {
+  /** Return the raw bytes for this hash. */
+  asBytes(): Uint8Array;
+  /** String representation, typically hex encoded. */
+  toString(): string;
+}

--- a/packages/core/test/channel/blake2_channel.test.ts
+++ b/packages/core/test/channel/blake2_channel.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { Blake2sChannel } from '../../src/channel/blake2';
+import { QM31 as SecureField } from '../../src/fields/qm31';
+import { M31 } from '../../src/fields/m31';
+
+describe('Blake2sChannel', () => {
+  it('channel_time', () => {
+    const ch = new Blake2sChannel();
+    expect(ch.channel_time.n_challenges).toBe(0);
+    expect(ch.channel_time.n_sent).toBe(0);
+
+    ch.draw_random_bytes();
+    expect(ch.channel_time.n_challenges).toBe(0);
+    expect(ch.channel_time.n_sent).toBe(1);
+
+    ch.draw_felts(9);
+    expect(ch.channel_time.n_challenges).toBe(0);
+    expect(ch.channel_time.n_sent).toBe(6);
+  });
+
+  it('draw_random_bytes returns different values', () => {
+    const ch = new Blake2sChannel();
+    const first = ch.draw_random_bytes();
+    const second = ch.draw_random_bytes();
+    expect(Buffer.from(first).equals(Buffer.from(second))).toBe(false);
+  });
+
+  it('draw_felt returns different values', () => {
+    const ch = new Blake2sChannel();
+    const first = ch.draw_felt();
+    const second = ch.draw_felt();
+    expect(first.equals(second)).toBe(false);
+  });
+
+  it('draw_felts returns unique values', () => {
+    const ch = new Blake2sChannel();
+    const vals = ch.draw_felts(5).concat(ch.draw_felts(4));
+    const set = new Set(vals.map(v => v.toString()));
+    expect(set.size).toBe(vals.length);
+  });
+
+  it('mix_felts changes digest', () => {
+    const ch = new Blake2sChannel();
+    const initial = Buffer.from(ch.digestBytes()).toString('hex');
+    const felts = [0,1].map(i => SecureField.fromM31Array([
+      M31.from(i+1923782), M31.from(i+1923783), M31.from(i+1923784), M31.from(i+1923785)
+    ]));
+    ch.mix_felts(felts);
+    expect(Buffer.from(ch.digestBytes()).toString('hex')).not.toBe(initial);
+  });
+
+  it('mix_u64 equals mix_u32s', () => {
+    const ch1 = new Blake2sChannel();
+    ch1.mix_u64(Number(BigInt('0x1111222233334444')));
+    const digest64 = Buffer.from(ch1.digestBytes()).toString('hex');
+
+    const ch2 = new Blake2sChannel();
+    ch2.mix_u32s([0x33334444, 0x11112222]);
+    expect(Buffer.from(ch2.digestBytes()).toString('hex')).toBe(digest64);
+  });
+});

--- a/packages/core/test/vcs/blake2_hash.test.ts
+++ b/packages/core/test/vcs/blake2_hash.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { Blake2sHash, Blake2sHasher } from '../../src/vcs/blake2_hash';
+
+function hex(hash: Blake2sHash): string { return hash.toString(); }
+
+describe('Blake2sHasher', () => {
+  it('single_hash_test', () => {
+    const hashA = Blake2sHasher.hash(new TextEncoder().encode('a'));
+    expect(hex(hashA)).toBe('4a0d129873403037c2cd9b9048203687f6233fb6738956e0349bd4320fec3e90');
+  });
+
+  it('hash_state_test', () => {
+    const state = new Blake2sHasher();
+    state.update(new TextEncoder().encode('a'));
+    state.update(new TextEncoder().encode('b'));
+    const hash = state.finalizeReset();
+    const hashEmpty = state.finalize();
+
+    expect(hex(hash)).toBe(hex(Blake2sHasher.hash(new TextEncoder().encode('ab'))));
+    expect(hex(hashEmpty)).toBe(hex(Blake2sHasher.hash(new Uint8Array())));
+  });
+});


### PR DESCRIPTION
## Summary
- implement Blake2sHasher using OpenSSL fallback
- add Blake2sChannel and basic channel interfaces
- create tests for blake2 channel and hasher

## Testing
- `bun run lint`
- `bun run test`