### PR TITLE
[core] fix mix_u64 precision

### DIFF
--- a/packages/core/src/channel/blake2.ts
+++ b/packages/core/src/channel/blake2.ts
@@ -277,9 +277,10 @@ export class Blake2sChannel implements Channel {
     this.updateDigest(hasher.finalize());
   }
 
-  mix_u64(value: number): void {
-    const low = value >>> 0;
-    const high = Math.floor(value / 2 ** 32) >>> 0;
+  mix_u64(value: number | bigint): void {
+    const v = BigInt(value);
+    const low = Number(v & 0xffffffffn);
+    const high = Number((v >> 32n) & 0xffffffffn);
     this.mix_u32s([low, high]);
   }
 

--- a/packages/core/src/channel/index.ts
+++ b/packages/core/src/channel/index.ts
@@ -91,7 +91,7 @@ export interface Channel {
 
   mix_u32s(data: readonly number[]): void;
   mix_felts(felts: readonly SecureField[]): void;
-  mix_u64(value: number): void;
+  mix_u64(value: number | bigint): void;
 
   draw_felt(): SecureField;
   draw_felts(n_felts: number): SecureField[];

--- a/packages/core/test/channel/blake2_channel.test.ts
+++ b/packages/core/test/channel/blake2_channel.test.ts
@@ -51,7 +51,7 @@ describe('Blake2sChannel', () => {
 
   it('mix_u64 equals mix_u32s', () => {
     const ch1 = new Blake2sChannel();
-    ch1.mix_u64(Number(BigInt('0x1111222233334444')));
+    ch1.mix_u64(0x1111222233334444n);
     const digest64 = Buffer.from(ch1.digestBytes()).toString('hex');
 
     const ch2 = new Blake2sChannel();


### PR DESCRIPTION
## Summary
- handle bigint in `mix_u64`
- update channel interface to accept bigint
- adjust blake2 channel tests for bigint input

## Testing
- `bun run lint`
- `bun run test`
