### PR TITLE
[core] add domain aliases and line poly

### DIFF
--- a/packages/core/src/fields/m31.ts
+++ b/packages/core/src/fields/m31.ts
@@ -48,6 +48,14 @@ export class M31 implements Field<M31> {
   }
 
   /**
+   * Constructs an M31 element from a raw unsigned 32‑bit value without
+   * range checking. Mirrors the Rust `from_u32_unchecked` constructor.
+   */
+  static from_u32_unchecked(val: number): M31 {
+    return new M31(val);
+  }
+
+  /**
    * Returns the additive inverse of this element
    */
   neg(): M31 {

--- a/packages/core/src/fields/qm31.ts
+++ b/packages/core/src/fields/qm31.ts
@@ -20,6 +20,14 @@ export class QM31 implements Field<QM31>, ExtensionOf<CM31, QM31> {
     return new QM31(CM31.fromUnchecked(a, b), CM31.fromUnchecked(c, d));
   }
 
+  /**
+   * Constructs a QM31 element from raw u32 components without range checks.
+   * Mirrors the Rust `from_u32_unchecked` helper.
+   */
+  static from_u32_unchecked(a: number, b: number, c: number, d: number): QM31 {
+    return new QM31(CM31.fromUnchecked(a, b), CM31.fromUnchecked(c, d));
+  }
+
   static fromM31(a: M31, b: M31, c: M31, d: M31): QM31 {
     return new QM31(CM31.fromM31(a, b), CM31.fromM31(c, d));
   }

--- a/packages/core/src/poly/circle/domain.ts
+++ b/packages/core/src/poly/circle/domain.ts
@@ -231,6 +231,11 @@ export class CircleDomain {
     return this.halfCoset.log_size + 1;
   }
 
+  /** Alias for Rust-style `log_size` method name. */
+  log_size(): number {
+    return this.logSize();
+  }
+
   /** Returns the `i`th domain element. */
   at(i: number): CirclePoint<M31> {
     return this.indexAt(i).to_point();
@@ -246,6 +251,11 @@ export class CircleDomain {
     // Assuming CirclePointIndex supports negation in some way
     // Use a type assertion to handle this for now
     return -index as unknown as CirclePointIndex;
+  }
+
+  /** Alias for Rust-style `index_at` method name. */
+  index_at(i: number): CirclePointIndex {
+    return this.indexAt(i);
   }
 
   /** Returns true if the domain is canonic. */
@@ -271,6 +281,11 @@ export class CircleDomain {
   /** Returns a shifted domain by the given offset. */
   shift(shift: CirclePointIndex): CircleDomain {
     return CircleDomain.new(this.halfCoset.shift(shift));
+  }
+
+  /** Returns the underlying half coset. */
+  coset(): Coset {
+    return this.halfCoset;
   }
 
   /** Enables `for...of` iteration over the domain points. */

--- a/packages/core/src/poly/circle/poly.ts
+++ b/packages/core/src/poly/circle/poly.ts
@@ -46,6 +46,26 @@ export class CirclePoly<B extends ColumnOps<any>> {
     const BClass: any = (this.constructor as any);
     return BClass.evaluate(this, domain, twiddles);
   }
+
+  /** Check if the polynomial lies in the FFT space of size `2^logFftSize`. */
+  isInFftSpace(logFftSize: number): boolean {
+    const coeffs = [...this.coeffs];
+    while (coeffs.length > 0 && typeof coeffs[coeffs.length - 1].isZero === "function" && coeffs[coeffs.length - 1].isZero()) {
+      coeffs.pop();
+    }
+    const highest = 1 << logFftSize;
+    return coeffs.length <= highest;
+  }
+
+  /** Check if the polynomial lies in the FRI space of size `2^logFftSize`. */
+  isInFriSpace(logFftSize: number): boolean {
+    const coeffs = [...this.coeffs];
+    while (coeffs.length > 0 && typeof coeffs[coeffs.length - 1].isZero === "function" && coeffs[coeffs.length - 1].isZero()) {
+      coeffs.pop();
+    }
+    const highest = (1 << logFftSize) + 1;
+    return coeffs.length <= highest;
+  }
 }
 
 /*

--- a/packages/core/src/poly/line.ts
+++ b/packages/core/src/poly/line.ts
@@ -1,5 +1,10 @@
 import { Coset, CirclePoint } from "../circle";
-import type { M31 } from "../fields/m31";
+import { M31 } from "../fields/m31";
+import { QM31 } from "../fields/qm31";
+import { CpuBackend } from "../backend/cpu";
+import { ibutterfly } from "../fft";
+import { bitReverseIndex } from "../utils";
+import { fold } from "./utils";
 
 /** A domain comprising the x-coordinates of points in a coset. */
 export class LineDomain {
@@ -28,6 +33,11 @@ export class LineDomain {
     return this.coset.log_size;
   }
 
+  /** Alias for Rust-style `log_size` method name. */
+  log_size(): number {
+    return this.logSize();
+  }
+
   *iter(): IterableIterator<M31> {
     const it: Iterable<CirclePoint<M31>> = this.coset.iter();
     for (const p of it) {
@@ -39,8 +49,120 @@ export class LineDomain {
     return new LineDomain(this.coset.double());
   }
 
-  cosetValue(): Coset {
+  /** Returns the domain's underlying coset. */
+  coset(): Coset {
     return this.coset;
+  }
+}
+
+/** A univariate polynomial defined on a LineDomain. */
+export class LinePoly {
+  coeffs: QM31[];
+  log_size: number;
+
+  constructor(coeffs: QM31[]) {
+    if (coeffs.length === 0 || (coeffs.length & (coeffs.length - 1)) !== 0) {
+      throw new Error("coeffs length must be power of two");
+    }
+    this.coeffs = coeffs.slice();
+    this.log_size = Math.log2(coeffs.length);
+  }
+
+  static new(coeffs: QM31[]): LinePoly {
+    return new LinePoly(coeffs);
+  }
+
+  len(): number {
+    return this.coeffs.length;
+  }
+
+  eval_at_point(x: QM31): QM31 {
+    let cur = x;
+    const doublings: QM31[] = [];
+    for (let i = 0; i < this.log_size; i++) {
+      doublings.push(cur);
+      cur = CirclePoint.double_x(cur, QM31);
+    }
+    return fold(this.coeffs, doublings);
+  }
+
+  into_ordered_coefficients(): QM31[] {
+    const arr = this.coeffs.slice();
+    bitReverseArray(arr);
+    return arr;
+  }
+
+  static from_ordered_coefficients(coeffs: QM31[]): LinePoly {
+    const arr = coeffs.slice();
+    bitReverseArray(arr);
+    return new LinePoly(arr);
+  }
+}
+
+export class LineEvaluation<B = CpuBackend> {
+  domain: LineDomain;
+  values: QM31[];
+
+  constructor(domain: LineDomain, values: QM31[]) {
+    if (domain.size() !== values.length) throw new Error("size mismatch");
+    this.domain = domain;
+    this.values = values.slice();
+  }
+
+  static new(domain: LineDomain, values: QM31[]): LineEvaluation<B> {
+    return new LineEvaluation(domain, values);
+  }
+
+  static new_zero(domain: LineDomain, zero: QM31): LineEvaluation<B> {
+    return new LineEvaluation(domain, Array(domain.size()).fill(zero));
+  }
+
+  len(): number {
+    return this.values.length;
+  }
+
+  to_cpu(): LineEvaluation {
+    return new LineEvaluation(this.domain, this.values);
+  }
+
+  interpolate(): LinePoly {
+    const vals = this.values.slice();
+    bitReverseArray(vals);
+    lineIFFT(vals, this.domain);
+    const lenInv = M31.from_u32_unchecked(vals.length as number).inverse();
+    for (let i = 0; i < vals.length; i++) {
+      vals[i] = vals[i].mulM31(lenInv);
+    }
+    return new LinePoly(vals);
+  }
+}
+
+/** In-place line-domain inverse FFT. */
+function lineIFFT(values: QM31[], domain: LineDomain) {
+  let d = domain;
+  while (d.size() > 1) {
+    for (let chunkStart = 0; chunkStart < values.length; chunkStart += d.size()) {
+      for (let i = 0; i < d.size() / 2; i++) {
+        const idx0 = chunkStart + i;
+        const idx1 = idx0 + d.size() / 2;
+        const x = d.at(i).inverse();
+        const [v0, v1] = ibutterfly(values[idx0], values[idx1], x);
+        values[idx0] = v0;
+        values[idx1] = v1;
+      }
+    }
+    d = d.double();
+  }
+}
+
+function bitReverseArray<T>(arr: T[]) {
+  const n = arr.length;
+  const logN = Math.log2(n);
+  for (let i = 0; i < n; i++) {
+    const j = bitReverseIndex(i, logN);
+    if (j > i) {
+      [arr[i], arr[j]] = [arr[j], arr[i]];
+    }
   }
 }
 

--- a/packages/core/test/poly/lineDomain.test.ts
+++ b/packages/core/test/poly/lineDomain.test.ts
@@ -17,11 +17,11 @@ describe("LineDomain", () => {
     expect(Array.from(domain.iter()).map(v => v.value)).toEqual(expected);
   });
 
-  it("at returns x and cosetValue exposes coset", () => {
+  it("at returns x and coset exposes coset", () => {
     const coset = Coset.subgroup(2);
     const domain = LineDomain.new(coset);
     expect(domain.at(1).value).toBe(coset.at(1).x.value);
-    expect(domain.cosetValue()).toBe(coset);
+    expect(domain.coset()).toBe(coset);
   });
   it("double halves the domain size", () => {
     const coset = Coset.subgroup(4);

--- a/packages/core/test/poly/lineEvaluation.test.ts
+++ b/packages/core/test/poly/lineEvaluation.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { LineDomain, LinePoly, LineEvaluation } from "../../src/poly/line";
+import { Coset } from "../../src/circle";
+import { QM31 } from "../../src/fields/qm31";
+
+// Simple polynomial 1 + 2*x + 3*pi(x) + 4*pi(x)*x over domain size 4
+const coeffs = [
+  QM31.from_u32_unchecked(1,0,0,0),
+  QM31.from_u32_unchecked(2,0,0,0),
+  QM31.from_u32_unchecked(3,0,0,0),
+  QM31.from_u32_unchecked(4,0,0,0),
+];
+
+function evalPoly(poly: LinePoly, domain: LineDomain): QM31[] {
+  const res: QM31[] = [];
+  for (const x of domain.iter()) {
+    res.push(poly.eval_at_point(x as unknown as QM31));
+  }
+  return res;
+}
+
+describe("LineEvaluation", () => {
+  it("interpolate round trip", () => {
+    const coset = Coset.half_odds(2);
+    const domain = LineDomain.new(coset);
+    const poly = new LinePoly(coeffs);
+    const values = evalPoly(poly, domain);
+    const evals = new LineEvaluation(domain, values);
+    const interp = evals.interpolate();
+    expect(interp.coeffs.map(c=>c.toM31Array()[0])).toEqual(poly.coeffs.map(c=>c.toM31Array()[0]));
+  });
+});


### PR DESCRIPTION
## Summary
- add log_size and index_at helpers for CircleDomain
- expose LineDomain.coset and matching log_size alias
- implement LinePoly and LineEvaluation with FFT helpers
- hook up CpuBackend FRI ops to generic folding helpers
- add unit tests for line domain and line evaluation

## Testing
- `bun run lint`
- `bun run test` *(fails: fold_line, fold_circle_into_line, missing blake2 module)*