### PR TITLE
[core] add field constants and is_zero aliases

### DIFF
--- a/packages/core/src/fields/m31.ts
+++ b/packages/core/src/fields/m31.ts
@@ -10,6 +10,11 @@ export const P: number = 2147483647; // 2^31 - 1
  */
 export class M31 implements Field<M31> {
   public readonly value: number;
+  // Provide static constants mirroring the Rust API. These are useful for
+  // places in the codebase (e.g. fri.ts) that expect `SecureField.ZERO` and
+  // `SecureField.ONE` style accessors instead of the `zero()`/`one()` methods.
+  static readonly ZERO: M31 = new M31(0);
+  static readonly ONE: M31 = new M31(1);
 
   constructor(value: number) {
     this.value = value;
@@ -201,6 +206,13 @@ export class M31 implements Field<M31> {
    */
   isZero(): boolean {
     return this.value === 0;
+  }
+
+  /**
+   * Alias for isZero() using snake_case naming to mirror the Rust API.
+   */
+  is_zero(): boolean {
+    return this.isZero();
   }
 
   /**

--- a/packages/core/src/fields/qm31.ts
+++ b/packages/core/src/fields/qm31.ts
@@ -10,6 +10,12 @@ export const SECURE_EXTENSION_DEGREE = 4;
 export class QM31 implements Field<QM31>, ExtensionOf<CM31, QM31> {
   readonly EXTENSION_DEGREE = 4;
 
+  // Static constants mirroring the Rust API. These help integrate with code
+  // that expects `SecureField.ZERO` and `SecureField.ONE` without calling the
+  // corresponding methods.
+  static readonly ZERO: QM31 = new QM31(CM31.zero(), CM31.zero());
+  static readonly ONE: QM31 = new QM31(CM31.one(), CM31.zero());
+
   constructor(public readonly c0: CM31, public readonly c1: CM31) {}
 
   clone(): QM31 {
@@ -136,6 +142,13 @@ export class QM31 implements Field<QM31>, ExtensionOf<CM31, QM31> {
 
   isZero(): boolean {
     return this.c0.isZero() && this.c1.isZero();
+  }
+
+  /**
+   * Alias for isZero() using snake_case style expected by some translated code.
+   */
+  is_zero(): boolean {
+    return this.isZero();
   }
 
   static one(): QM31 {


### PR DESCRIPTION
## Summary
- extend `M31` and `QM31` with static `ZERO`/`ONE` constants
- add `is_zero()` alias for `isZero()` in both field types
- expose constants to satisfy `fri.ts` requirements

## Testing
- `bun test` *(fails: Cannot find module '@noble/hashes/blake2')*