### PR TITLE
[core] switch to noble hashes

### DIFF
--- a/packages/core/src/backend/cpu/blake2.ts
+++ b/packages/core/src/backend/cpu/blake2.ts
@@ -64,11 +64,7 @@ impl MerkleOps<Blake2sMerkleHasher> for CpuBackend {
 // outputs with the Rust version if possible, or by testing against known Merkle
 // tree structures.
 
-import { createHash } from 'crypto';
-let nobleBlake2s: ((data: Uint8Array) => Uint8Array) | undefined;
-try {
-  ({ blake2s: nobleBlake2s } = await import('@noble/hashes/blake2'));
-} catch {}
+import { blake2s } from '@noble/hashes/blake2.js';
 
 export type Blake2sHash = Uint8Array; // Represents a 32-byte hash
 
@@ -155,13 +151,7 @@ export function commitOnLayer(
       message = numbersToLEUint8Array(leafNumbers);
     }
     
-    if (nobleBlake2s) {
-      result[i] = nobleBlake2s(message);
-    } else {
-      const h = createHash('blake2s256');
-      h.update(message);
-      result[i] = new Uint8Array(h.digest());
-    }
+    result[i] = blake2s(message);
   }
   return result;
 }

--- a/packages/core/test/vcs/prover.test.ts
+++ b/packages/core/test/vcs/prover.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { createHash } from 'crypto';
+import { sha256 } from '@noble/hashes/sha256.js';
 import { M31 } from '../../src/fields/m31';
 import type { MerkleHasher, MerkleOps } from '../../src/vcs/ops';
 import { MerkleProver } from '../../src/vcs/prover';
@@ -7,7 +7,7 @@ import { MerkleVerifier } from '../../src/vcs/verifier';
 
 class SimpleHasher implements MerkleHasher<Uint8Array> {
   hashNode(children: [Uint8Array, Uint8Array] | undefined, values: readonly M31[]): Uint8Array {
-    const h = createHash('sha256');
+    const h = sha256.create();
     if (children) {
       h.update(children[0]);
       h.update(children[1]);

--- a/packages/core/test/vcs/verifier.test.ts
+++ b/packages/core/test/vcs/verifier.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { createHash } from "crypto";
+import { sha256 } from '@noble/hashes/sha256.js';
 import { M31 } from "../../src/fields/m31";
 import { MerkleVerifier, MerkleDecommitment, MerkleVerificationError } from "../../src/vcs/verifier";
 import type { MerkleHasher } from "../../src/vcs/ops";
 
 class SimpleHasher implements MerkleHasher<Uint8Array> {
   hashNode(children: [Uint8Array, Uint8Array] | undefined, values: readonly M31[]): Uint8Array {
-    const h = createHash("sha256");
+    const h = sha256.create();
     if (children) {
       h.update(children[0]);
       h.update(children[1]);


### PR DESCRIPTION
## Summary
- replace crypto usage with `@noble/hashes`
- update Merkle tests to use noble sha256

## Testing
- `bun run lint`
- `bun run test` *(fails: Cannot find module '@noble/hashes/blake2.js')*
- `bun vitest run --coverage` *(fails: Script not found 'vitest')*