### PR TITLE
[docs] Add field module documentation

### DIFF
--- a/docs/fields/README.md
+++ b/docs/fields/README.md
@@ -1,0 +1,23 @@
+---
+title: Fields Documentation
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+# Orientation
+
+This folder documents the TypeScript modules under `packages/core/src/fields`.
+
+## Layout
+
+- `overview.md` – high level narrative.
+- `<module>.md` – one document per exported module (`m31`, `cm31`, `qm31`, `fields`, `secure_columns`).
+- `glossary.md` – terminology and symbols.
+- `assets/` – diagrams used by the docs.
+
+## Reading Order
+
+1. Start with `overview.md`.
+2. Refer to module docs as needed.
+
+All diagrams use Mermaid unless otherwise noted. Equations are formatted in LaTeX.

--- a/docs/fields/cm31.md
+++ b/docs/fields/cm31.md
@@ -1,0 +1,39 @@
+---
+title: CM31
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+## Executive summary
+
+`CM31` is the quadratic extension field of `M31`, storing elements as pairs $(a,b)$ representing $a+bi$. Operations closely follow the Rust implementation with optimisations for zero and one.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `P2` | [cm31.ts:L5](../packages/core/src/fields/cm31.ts#L5) |
+| `CM31` | [cm31.ts:L12-L413](../packages/core/src/fields/cm31.ts#L12-L413) |
+
+## Walkthrough
+
+Construction validates each coordinate is in $[0,P)$ via `from_u32_unchecked`.
+Addition, subtraction and multiplication operate componentwise with early exits when results are zero.
+
+Inversion uses the identity
+$$ (a+bi)^{-1} = \frac{a-bi}{a^2+b^2}. $$
+Lines [237-251](../packages/core/src/fields/cm31.ts#L237-L251) implement this formula.
+
+## Usage
+
+```typescript
+import { CM31, M31 } from '@tstwo/core';
+const z = CM31.from_m31(M31.ONE, M31.ONE);
+const inv = z.inverse();
+```
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 8072ec5 | Initial documentation |

--- a/docs/fields/fields.md
+++ b/docs/fields/fields.md
@@ -1,0 +1,44 @@
+---
+title: Field Utilities
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+## Executive summary
+
+`fields.ts` defines interfaces shared by all field implementations and provides batch inversion utilities.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `FieldExpOps` | [fields.ts:L6-L12](../packages/core/src/fields/fields.ts#L6-L12) |
+| `Field` | [fields.ts:L17-L25](../packages/core/src/fields/fields.ts#L17-L25) |
+| `ExtensionOf` | [fields.ts:L30-L32](../packages/core/src/fields/fields.ts#L30-L32) |
+| `IntoSlice` | [fields.ts:L37-L39](../packages/core/src/fields/fields.ts#L37-L39) |
+| `ComplexConjugate` | [fields.ts:L44-L46](../packages/core/src/fields/fields.ts#L44-L46) |
+| `batchInverseClassic` | [fields.ts:L66-L91](../packages/core/src/fields/fields.ts#L66-L91) |
+| `batchInverseInPlace` | [fields.ts:L96-L160](../packages/core/src/fields/fields.ts#L96-L160) |
+| `batchInverse` | [fields.ts:L165-L180](../packages/core/src/fields/fields.ts#L165-L180) |
+| `batchInverseChunked` | [fields.ts:L183-L207](../packages/core/src/fields/fields.ts#L183-L207) |
+| `FieldUtils` | [fields.ts:L212-L230](../packages/core/src/fields/fields.ts#L212-L230) |
+| `TestUtils` | [fields.ts:L232-L281](../packages/core/src/fields/fields.ts#L232-L281) |
+
+## Walkthrough
+
+`batchInverseClassic` multiplies all elements cumulatively and then walks backward applying a single inverse to compute each element's inverse. `batchInverseInPlace` applies Montgomery's trick with a width of 4 for better cache behaviour.
+
+The helpers under `FieldUtils` mirror small utilities used throughout the codebase.
+
+## Usage
+
+```typescript
+import { batchInverse } from '@tstwo/core';
+const invs = batchInverse([M31.one(), M31.from(2)]);
+```
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 8072ec5 | Initial documentation |

--- a/docs/fields/glossary.md
+++ b/docs/fields/glossary.md
@@ -1,0 +1,15 @@
+---
+title: Glossary
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+**M31**: Prime field with modulus $2^{31}-1$.
+
+**CM31**: Quadratic extension of M31, elements written $a+bi$.
+
+**QM31**: Quartic extension of CM31, basis $(1,u)$ with $u^2=2+i$.
+
+**Secure Field**: Alias for `QM31`.
+
+**Batch Inversion**: Technique for computing inverses of many field elements using two passes of multiplication and a single inverse.

--- a/docs/fields/m31.md
+++ b/docs/fields/m31.md
@@ -1,0 +1,64 @@
+---
+title: M31
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+## Executive summary
+
+`M31` implements a prime field with modulus $P=2^{31}-1$ using 32‑bit integers. It exposes addition, subtraction, multiplication, and inversion operations, mirroring the Rust implementation from StarkWare's `stwo` project.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `MODULUS_BITS` | [m31.ts:L4](../packages/core/src/fields/m31.ts#L4) |
+| `N_BYTES_FELT` | [m31.ts:L5](../packages/core/src/fields/m31.ts#L5) |
+| `P` | [m31.ts:L6](../packages/core/src/fields/m31.ts#L6) |
+| `M31` | [m31.ts:L11-L292](../packages/core/src/fields/m31.ts#L11-L292) |
+| `BaseField` | [m31.ts:L294-L295](../packages/core/src/fields/m31.ts#L294-L295) |
+| `pow2147483645` | [m31.ts:L297-L314](../packages/core/src/fields/m31.ts#L297-L314) |
+
+## Walkthrough
+
+The constructor is private to ensure values remain in $[0,P)$:
+```typescript
+class M31 implements Field<M31> {
+  private constructor(value: number) {
+    this.value = value;
+  }
+}
+```
+
+Reduction uses the bit‑trick from Rust:
+```typescript
+static reduce(val: number | bigint): M31 {
+  const valBig = M31._validateAndNormalizeToBigInt(val);
+  return M31._reduceBig(valBig);
+}
+```
+Lines [60-101](../packages/core/src/fields/m31.ts#L60-L101) show the exact steps.
+
+The exponentiation chain for inverses is implemented in `pow2147483645` and is used by `inverse()`.
+
+## Usage
+
+```typescript
+import { M31 } from '@tstwo/core';
+const x = M31.from(123);
+const y = x.inverse();
+```
+
+## Performance
+
+All operations run in constant time over 32‑bit integers. The optimized inverse requires 37 multiplications.
+
+## FAQs
+- Values are validated to be integers before reduction.
+- `fromUnchecked` is deprecated; prefer `from_u32_unchecked`.
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 8072ec5 | Initial documentation |

--- a/docs/fields/overview.md
+++ b/docs/fields/overview.md
@@ -1,0 +1,15 @@
+---
+title: Field Modules Overview
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+The `fields` directory implements finite field arithmetic used across the project. Three field types are provided:
+
+- `M31` – a prime field with modulus $2^{31}-1$.
+- `CM31` – a quadratic extension of `M31` representing $a+bi$.
+- `QM31` – a quartic extension of `CM31` used as the project's *secure field*.
+
+Utility functions handle batch inversion and column management.
+
+Each module document explains its API, with references back to the TypeScript sources.

--- a/docs/fields/qm31.md
+++ b/docs/fields/qm31.md
@@ -1,0 +1,47 @@
+---
+title: QM31
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+## Executive summary
+
+`QM31` extends `CM31` by a further quadratic factor with basis $(1,u)$ where $u^2=2+i$. It serves as the secure field for polynomial commitments.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `P4` | [qm31.ts:L5](../packages/core/src/fields/qm31.ts#L5) |
+| `SECURE_EXTENSION_DEGREE` | [qm31.ts:L6](../packages/core/src/fields/qm31.ts#L6) |
+| `FieldError` | [qm31.ts:L14-L19](../packages/core/src/fields/qm31.ts#L14-L19) |
+| `QM31` | [qm31.ts:L29-L517](../packages/core/src/fields/qm31.ts#L29-L517) |
+| `SecureField` | [qm31.ts:L516-L517](../packages/core/src/fields/qm31.ts#L516-L517) |
+
+## Walkthrough
+
+Multiplication follows the rule
+$$
+(a+bu)(c+du) = (ac + Rbd) + (ad + bc)u,
+$$
+where $R=2+i$. See lines [280-296](../packages/core/src/fields/qm31.ts#L280-L296).
+
+Inversion implements equation
+$$
+(a+bu)^{-1} = \frac{a-bu}{a^2-(2+i)b^2},
+$$
+matching the Rust code at lines [403-419](../packages/core/src/fields/qm31.ts#L403-L419).
+
+## Usage
+
+```typescript
+import { QM31 } from '@tstwo/core';
+const e = QM31.from_u32_unchecked(1,0,0,0);
+const inv = e.inverse();
+```
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 8072ec5 | Initial documentation |

--- a/docs/fields/secure_columns.md
+++ b/docs/fields/secure_columns.md
@@ -1,0 +1,33 @@
+---
+title: Secure Columns
+last-verified: 2024-05-25
+source-hash: 8072ec5c35ed072a0b96695700613743d8b8a056
+---
+
+## Executive summary
+
+`secure_columns.ts` provides `SecureColumnByCoords`, a column-major container for `QM31` elements used in the CPU backend.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `SecureColumnByCoords` | [secure_columns.ts:L121-L211](../packages/core/src/fields/secure_columns.ts#L121-L211) |
+
+## Walkthrough
+
+The class stores four arrays of `M31` coordinates (see line [121](../packages/core/src/fields/secure_columns.ts#L121)). `at(index)` reconstructs a `QM31` element from these arrays, while `set(index,value)` writes back its coordinates.
+
+## Usage
+
+```typescript
+import { SecureColumnByCoords, QM31 } from '@tstwo/core';
+const col = SecureColumnByCoords.zeros(8);
+col.set(0, QM31.ONE);
+```
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 8072ec5 | Initial documentation |

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "bun test",
     "coverage": "bun vitest run --coverage",
     "bench": "bun run bench/m31.bench.ts",
-    "lint": "eslint . --max-warnings=1000 --no-error-on-unmatched-pattern"
+    "lint": "eslint . --max-warnings=1000 --no-error-on-unmatched-pattern",
+    "docs:check": "markdownlint \"docs/**/*.md\""
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -23,7 +24,8 @@
     "@vitest/coverage-istanbul": "^3.1.3",
     "eslint": "^9.27.0",
     "vite": "^6.3.5",
-    "vitest": "^3.1.3"
+    "vitest": "^3.1.3",
+    "markdownlint-cli": "^0.39.0"
   },
   "peerDependencies": {
     "typescript": "^5"


### PR DESCRIPTION
## Summary
- document field modules under `packages/core/src/fields`
- add `docs:check` script with markdownlint

## Testing
- `bun run docs:check` *(fails: markdownlint not found)*
- `bun run lint`
- `bun run build` *(fails: vite not found)*
- `bun run test` *(fails: module resolution errors)*