### PR TITLE
[docs] Add channel module documentation

### DIFF
--- a/docs/channel/README.md
+++ b/docs/channel/README.md
@@ -1,0 +1,23 @@
+---
+title: Channel Documentation
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+# Orientation
+
+This folder documents the TypeScript modules under `packages/core/src/channel`.
+
+## Layout
+
+- `overview.md` – high level narrative.
+- `<module>.md` – one document per exported module (`index`, `blake2`, `poseidon`, `logging_channel`).
+- `glossary.md` – terminology and symbols.
+- `assets/` – diagrams used by the docs.
+
+## Reading Order
+
+1. Start with `overview.md`.
+2. Refer to module docs as needed.
+
+All diagrams use Mermaid unless otherwise noted. Equations are formatted in LaTeX.

--- a/docs/channel/blake2.md
+++ b/docs/channel/blake2.md
@@ -1,0 +1,57 @@
+---
+title: Blake2sChannel
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+## Executive summary
+
+`Blake2sChannel` mixes inputs using Blake2s hashing and draws `QM31` elements in batches of eight base field elements. It is the default random oracle for proofs.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `BLAKE_BYTES_PER_HASH` | [blake2.ts:L8](../packages/core/src/channel/blake2.ts#L8) |
+| `FELTS_PER_HASH` | [blake2.ts:L9](../packages/core/src/channel/blake2.ts#L9) |
+| `Blake2sChannel` | [blake2.ts:L25-L225](../packages/core/src/channel/blake2.ts#L25-L225) |
+
+## Walkthrough
+
+The constructor is private and instances are created via `create()` or `fromState()`:
+```typescript
+static create(): Blake2sChannel {
+  return new Blake2sChannel(
+    Blake2sChannel._constructorKey,
+    new Blake2sHash(),
+    new MutableChannelTime(),
+    []
+  );
+}
+```
+Mixing `u32` values validates the input and hashes each word in little‑endian order:
+```typescript
+mix_u32s(data: readonly number[]): void {
+  ChannelUtils.validateU32Array(data);
+  const hasher = new Blake2sHasher();
+  hasher.update(this._digest.bytes);
+  const buf = new Uint8Array(4);
+  const view = new DataView(buf.buffer);
+  for (const word of data) {
+    view.setUint32(0, word >>> 0, true);
+    hasher.update(buf);
+  }
+  this.updateDigest(hasher.finalize());
+}
+```
+Drawing a `QM31` element composes four base field draws:
+```typescript
+const arr = this._baseQueue.splice(0, SECURE_EXTENSION_DEGREE) as [M31,M31,M31,M31];
+return SecureField.from_m31_array(arr);
+```
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 429a80c | Initial channel documentation |

--- a/docs/channel/glossary.md
+++ b/docs/channel/glossary.md
@@ -1,0 +1,15 @@
+---
+title: Glossary
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+**Channel**: Abstraction for a random oracle with mix and draw operations.
+
+**MerkleChannel**: Interface for channels that incorporate Merkle tree roots.
+
+**ChannelTime**: Counter of sent digests and challenge rounds.
+
+**FieldElement252**: 252‑bit field element matching Starknet's prime field.
+
+**SecureField**: Alias for `QM31`, the secure extension field used in proofs.

--- a/docs/channel/index.md
+++ b/docs/channel/index.md
@@ -1,0 +1,59 @@
+---
+title: Channel Interfaces
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+## Executive summary
+
+`index.ts` defines the common interfaces and helper utilities used by all channel implementations. It also exposes `ChannelTime` for tracking how many challenges were issued and how many messages were sent.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `EXTENSION_FELTS_PER_HASH` | [index.ts:L10](../packages/core/src/channel/index.ts#L10) |
+| `ChannelTime` | [index.ts:L20-L84](../packages/core/src/channel/index.ts#L20-L84) |
+| `MutableChannelTime` | [index.ts:L91-L109](../packages/core/src/channel/index.ts#L91-L109) |
+| `Channel` | [index.ts:L119-L137](../packages/core/src/channel/index.ts#L119-L137) |
+| `MerkleChannel` | [index.ts:L146-L148](../packages/core/src/channel/index.ts#L146-L148) |
+| `ChannelUtils` | [index.ts:L153-L182](../packages/core/src/channel/index.ts#L153-L182) |
+
+Re-exports of `Blake2sChannel`, `Poseidon252Channel` and `LoggingChannel` are defined at lines [5-7](../packages/core/src/channel/index.ts#L5-L7).
+
+## Walkthrough
+
+`ChannelTime` uses a private constructor and factory methods to enforce invariants:
+```typescript
+class ChannelTime {
+  private static readonly _constructorKey = Symbol('ChannelTime.constructor');
+  private constructor(key: symbol, private readonly _n_challenges = 0, private readonly _n_sent = 0) {
+    if (key !== ChannelTime._constructorKey) {
+      throw new Error('ChannelTime constructor is private. Use factory methods.');
+    }
+  }
+}
+```
+Counters are incremented by returning new immutable objects so that the public API remains pure.
+
+`MutableChannelTime` is the internal mutable equivalent used within channel implementations to avoid allocation overhead. Conversion functions `toMutable()` and `toImmutable()` bridge the two forms.
+
+The `Channel` interface specifies the basic mix and draw operations. `MerkleChannel` adds a single `mix_root` method for hashing Merkle tree roots.
+
+`ChannelUtils` validates integer inputs before they reach the hashing logic:
+```typescript
+export function validateU32Array(data: readonly number[]): void {
+  for (let i = 0; i < data.length; i++) {
+    if (!isValidU32(data[i]!)) {
+      throw new TypeError(`Invalid u32 value at index ${i}: ${data[i]}`);
+    }
+  }
+}
+```
+These guards prevent accidental overflow or negative values.
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 429a80c | Initial channel documentation |

--- a/docs/channel/logging_channel.md
+++ b/docs/channel/logging_channel.md
@@ -1,0 +1,39 @@
+---
+title: LoggingChannel
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+## Executive summary
+
+`logging_channel.ts` provides wrappers that log every mix and draw operation on an underlying channel. Logging can be enabled or disabled at creation time.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `ChannelLogger` | [logging_channel.ts:L9-L12](../packages/core/src/channel/logging_channel.ts#L9-L12) |
+| `ConsoleChannelLogger` | [logging_channel.ts:L17-L35](../packages/core/src/channel/logging_channel.ts#L17-L35) |
+| `LoggingChannel` | [logging_channel.ts:L47-L152](../packages/core/src/channel/logging_channel.ts#L47-L152) |
+| `LoggingMerkleChannel` | [logging_channel.ts:L162-L216](../packages/core/src/channel/logging_channel.ts#L162-L216) |
+
+## Walkthrough
+
+`LoggingChannel` forwards each call to the wrapped channel and records the before‑and‑after state using a user‑supplied `ChannelLogger`:
+```typescript
+mix_u32s(data: readonly number[]): void {
+  const initialState = this.getStateString();
+  this._channel.mix_u32s(data);
+  const newState = this.getStateString();
+  this._logger.logMix('mix_u32s', initialState, data, newState);
+}
+```
+The helper `getStateString()` attempts to render the digest as hexadecimal for readable logs.
+
+`LoggingMerkleChannel` performs similar instrumentation for Merkle root mixing. If the underlying channel does not expose `mix_root`, the wrapper falls back to mixing the root as bytes.
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 429a80c | Initial channel documentation |

--- a/docs/channel/overview.md
+++ b/docs/channel/overview.md
@@ -1,0 +1,12 @@
+---
+title: Channel Modules Overview
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+The `channel` directory contains implementations of random-oracle channels used across the proving system. A channel mixes data into an internal digest and draws pseudorandom field elements from it. Two concrete channels are provided:
+
+- `Blake2sChannel` – digest based on Blake2s hashes.
+- `Poseidon252Channel` – digest based on Poseidon hashes over the Starknet field.
+
+Utility wrappers add logging capabilities and common interfaces unify the API. Each module document explains the exported symbols and references back to the TypeScript sources.

--- a/docs/channel/poseidon.md
+++ b/docs/channel/poseidon.md
@@ -1,0 +1,43 @@
+---
+title: Poseidon252Channel
+last-verified: 2025-05-25
+source-hash: 429a80c36f02933c6a19442d9428c7511ccd46d4
+---
+
+## Executive summary
+
+`Poseidon252Channel` uses the Starknet Poseidon hash to produce random field elements. It works with 252‑bit field elements and derives base field elements by splitting the hash output.
+
+## Public surface
+
+| Symbol | Source |
+| --- | --- |
+| `BYTES_PER_FELT252` | [poseidon.ts:L8](../packages/core/src/channel/poseidon.ts#L8) |
+| `FELTS_PER_HASH` | [poseidon.ts:L9](../packages/core/src/channel/poseidon.ts#L9) |
+| `FieldElement252` | [poseidon.ts:L28-L110](../packages/core/src/channel/poseidon.ts#L28-L110) |
+| `Poseidon252Channel` | [poseidon.ts:L122-L360](../packages/core/src/channel/poseidon.ts#L122-L360) |
+
+## Walkthrough
+
+`FieldElement252` validates its value against Starknet's prime and exposes arithmetic operations. `Poseidon252Channel` keeps an internal digest and a mutable `ChannelTime`. Every mix updates the digest via `poseidonHash` or `poseidonHashMany`, and every draw increments the counters.
+
+Base field elements are derived from the digest by repeatedly dividing by $2^{31}$:
+```typescript
+let cur = this.drawFelt252();
+const u32s: number[] = [];
+for (let i = 0; i < 8; i++) {
+  const next = cur.floorDiv(FieldElement252.from(SHIFT_31));
+  const res = cur.sub(next.mul(FieldElement252.from(SHIFT_31)));
+  cur = next;
+  const u32Val = res.tryIntoU32();
+  if (u32Val === null) throw new Error('Failed to convert to u32');
+  u32s.push(u32Val);
+}
+```
+The resulting `u32s` are reduced into `M31` elements and grouped into `QM31` values.
+
+## Revision log
+
+| Commit | Description |
+| --- | --- |
+| 429a80c | Initial channel documentation |


### PR DESCRIPTION
## Summary
- document channel modules: index, Blake2s, Poseidon252, logging
- add folder orientation and glossary

## Testing
- `bun run lint`
- `bun run test` *(fails: Cannot find module '@scure/starknet')*
- `bun run docs:check` *(fails: markdownlint not found)*