### PR TITLE
[core] fix noble hash imports and default config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Any ./target folder
 target
 
+
+# rust reference repo
+rust-reference/stwo/

--- a/packages/core/src/backend/cpu/blake2.ts
+++ b/packages/core/src/backend/cpu/blake2.ts
@@ -34,7 +34,9 @@
 // outputs with the Rust version if possible, or by testing against known Merkle
 // tree structures.
 
-import { blake2s } from '@noble/hashes/blake2.js';
+// Import from the ESM-friendly path. Using the `.js` suffix caused Bun to throw
+// resolution errors during testing.
+import { blake2s } from '@noble/hashes/blake2s';
 
 export type Blake2sHash = Uint8Array; // Represents a 32-byte hash
 

--- a/packages/core/src/vcs/blake2_hash.ts
+++ b/packages/core/src/vcs/blake2_hash.ts
@@ -1,4 +1,6 @@
-import { blake2s } from '@noble/hashes/blake2.js';
+// bun struggles to resolve the `.js` suffixed path. Use the explicit
+// `blake2s` module which is exported for ESM environments.
+import { blake2s } from '@noble/hashes/blake2s';
 import type { HashLike } from './hash';
 
 /** Wrapper around a 32 byte BLAKE2s hash. */

--- a/packages/core/src/vcs/blake3_hash.ts
+++ b/packages/core/src/vcs/blake3_hash.ts
@@ -1,4 +1,5 @@
-import { blake3 } from '@noble/hashes/blake3.js';
+// Extensionless import improves compatibility across bundlers.
+import { blake3 } from '@noble/hashes/blake3';
 import type { HashLike } from './hash';
 
 const BLAKE3_OUT_LEN = 32; // blake3 default output length is 32 bytes

--- a/packages/core/test/vcs/prover.test.ts
+++ b/packages/core/test/vcs/prover.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { blake2s } from '@noble/hashes/blake2.js';
+// Use the extensionless path so Bun resolves the module.
+import { blake2s } from '@noble/hashes/blake2s';
 import { M31 } from '../../src/fields/m31';
 import type { MerkleHasher, MerkleOps } from '../../src/vcs/ops';
 import { MerkleProver } from '../../src/vcs/prover';

--- a/packages/core/test/vcs/verifier.test.ts
+++ b/packages/core/test/vcs/verifier.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { blake2s } from '@noble/hashes/blake2.js';
+// Bun cannot resolve the `.js` suffixed import. Use the module alias without it.
+import { blake2s } from '@noble/hashes/blake2s';
 import { M31 } from "../../src/fields/m31";
 import { MerkleVerifier, MerkleDecommitment, MerkleVerificationError } from "../../src/vcs/verifier";
 import type { MerkleHasher } from "../../src/vcs/ops";

--- a/test-equivalence/fields/securecolumn.test.ts
+++ b/test-equivalence/fields/securecolumn.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'bun:test';
 import { SecureColumnByCoords } from '../../packages/core/src/fields/secure_columns';
 import { QM31 } from '../../packages/core/src/fields/qm31';
-import testVectors from '../../test-vectors/securecolumn-test-vectors.json';
+import secureColumnVectors from '../../test-vectors/securecolumn-test-vectors.json';
+
+// The JSON structure wraps vectors in a `test_vectors` array. Extract it once
+// so tests operate on the expected array of vector objects.
+const testVectors = secureColumnVectors.test_vectors;
 
 describe('SecureColumn Test Vector Validation', () => {
   describe('Column Operations', () => {

--- a/test-equivalence/stwo-examples-equivalence/typescript-examples/03_committing_to_the_trace_polynomials.ts
+++ b/test-equivalence/stwo-examples-equivalence/typescript-examples/03_committing_to_the_trace_polynomials.ts
@@ -141,7 +141,11 @@ class CommitmentTreeProver {
 // ANCHOR: here_1
 const CONSTRAINT_EVAL_BLOWUP_FACTOR = 1;
 
-export function committingToTheTracePolynomials(config: TableConfig) {
+// Provide a default configuration so tests can invoke this example without
+// manually supplying values, matching the pattern used in other examples.
+export function committingToTheTracePolynomials(
+    config: TableConfig = DEFAULT_TABLE_CONFIG,
+) {
     // --snip--
     // ANCHOR_END: here_1
     


### PR DESCRIPTION
## Summary
- import noble hashes without `.js` suffix for bun compatibility
- set default config on committingToTheTracePolynomials example
- ignore rust reference clone directory

## Testing
- `bun run lint`
- `bun test` *(fails: several stwo-examples-equivalence tests)*

------
https://chatgpt.com/codex/tasks/task_e_6840482485748322a895ab00b8f372d5